### PR TITLE
DM-41836: Prompt Processing may wait too long for raws

### DIFF
--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -297,7 +297,8 @@ def next_visit_handler() -> Tuple[str, int]:
                 if startup_response:
                     response = startup_response
                 else:
-                    response = consumer.consume(num_messages=1, timeout=timeout)
+                    time_remaining = max(0.0, timeout - (time.time() - start))
+                    response = consumer.consume(num_messages=1, timeout=time_remaining + 1.0)
                 end = time.time()
                 messages = _filter_messages(response)
                 response = []


### PR DESCRIPTION
This PR fixes a logic error in the raw image arrival loop that caused irrelevant images to keep the activator trapped in the loop long after it should have timed out.