### PR TITLE
Add workaround to process y-band LATISS data.

### DIFF
--- a/pipelines/LATISS/ApPipe.yaml
+++ b/pipelines/LATISS/ApPipe.yaml
@@ -6,3 +6,9 @@ description: Alert Production pipeline specialized for LATISS
 # release schedule.
 imports:
   - location: $AP_PIPE_DIR/pipelines/LATISS/ApPipe.yaml
+tasks:
+  calibrate:
+    class: lsst.pipe.tasks.calibrate.CalibrateTask
+    config:
+      python: |
+        config.photoRefObjLoader.filterMap["y"] = "z"  # Workaround for DM-41909


### PR DESCRIPTION
This is a dummy PR to patch the LATISS filterMap for the time being. It can be closed once [DM-41909](https://jira.lsstcorp.org/browse/DM-41909) is fixed.