### PR TITLE
DM-41730: Exception logs don't have metadata

### DIFF
--- a/python/activator/logger.py
+++ b/python/activator/logger.py
@@ -235,7 +235,7 @@ class RecordFactoryContextAdapter:
     def _context(self, value):
         self._store.context = value
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, name, level, fn, lno, msg, args, exc_info, func=None, sinfo=None, **kwargs):
         """Create a log record from the provided arguments.
 
         See `logging.setLogRecordFactory` for the parameters.
@@ -247,7 +247,7 @@ class RecordFactoryContextAdapter:
             maps strings to arbitrary values, as determined by any enclosing
             calls to `add_context`.
         """
-        record = self._old_factory(*args, **kwargs)
+        record = self._old_factory(name, level, fn, lno, msg, args, exc_info, func, sinfo, **kwargs)
         # _context is mutable; make sure record can't be changed after the fact.
         record.logging_context = self._context.copy()
         return record

--- a/python/activator/logger.py
+++ b/python/activator/logger.py
@@ -250,6 +250,11 @@ class RecordFactoryContextAdapter:
         record = self._old_factory(name, level, fn, lno, msg, args, exc_info, func, sinfo, **kwargs)
         # _context is mutable; make sure record can't be changed after the fact.
         record.logging_context = self._context.copy()
+        if exc_info is not None:
+            _, ex, _ = exc_info  # Only care about the exception object passed to the logger
+            if hasattr(ex, "logging_context"):
+                # Context at the point where the exception was raised takes precedence.
+                record.logging_context.update(ex.logging_context)
         return record
 
     @contextmanager


### PR DESCRIPTION
This PR augments `RecordFactoryContextAdapter` to log exceptions with the context in which the exception was raised, not the one in which it was caught.