### PR TITLE
DM-42063: No task logs in Prompt Processing output

### DIFF
--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -35,6 +35,7 @@ import astropy
 
 from lsst.resources import ResourcePath
 import lsst.afw.cameraGeom
+import lsst.ctrl.mpexec
 from lsst.ctrl.mpexec import SeparablePipelineExecutor
 from lsst.daf.butler import Butler, CollectionType
 import lsst.dax.apdb
@@ -821,10 +822,12 @@ class MiddlewareInterface:
             exec_butler = Butler(butler=self.butler,
                                  collections=[output_run, init_output_run] + list(self.butler.collections),
                                  run=output_run)
+            factory = lsst.ctrl.mpexec.TaskFactory()
             executor = SeparablePipelineExecutor(
                 exec_butler,
                 clobber_output=False,
                 skip_existing_in=None,
+                task_factory=factory,
             )
             qgraph = executor.make_quantum_graph(pipeline, where=where)
             if len(qgraph) == 0:

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -818,12 +818,13 @@ class MiddlewareInterface:
                 raise RuntimeError from e
             init_output_run = self._get_init_output_run(pipeline_file, self._day_obs)
             output_run = self._get_output_run(pipeline_file, self._day_obs)
+            exec_butler = Butler(butler=self.butler,
+                                 collections=[output_run, init_output_run] + list(self.butler.collections),
+                                 run=output_run)
             executor = SeparablePipelineExecutor(
-                Butler(butler=self.butler,
-                       collections=[output_run, init_output_run] + list(self.butler.collections),
-                       run=output_run),
+                exec_butler,
                 clobber_output=False,
-                skip_existing_in=None
+                skip_existing_in=None,
             )
             qgraph = executor.make_quantum_graph(pipeline, where=where)
             if len(qgraph) == 0:


### PR DESCRIPTION
This PR turns off multiprocessing in pipeline execution, preventing a bug where task logs were not going through our logger. This is a mid-term workaround; we expect to restore compatibility with multiprocessing in the future.