### PR TITLE
DM-40823: Explore methods for calculating Prompt Processing preload timing

### DIFF
--- a/doc/playbook.rst
+++ b/doc/playbook.rst
@@ -195,6 +195,12 @@ A few useful commands for managing the service:
 Troubleshooting
 ---------------
 
+Printing Timing Logs
+^^^^^^^^^^^^^^^^^^^^
+
+The code is filled with timing blocks, but by default their logs are not emitted.
+To see timer results, set ``SERVICE_LOG_LEVELS`` to include ``timer.lsst.activator=DEBUG`` in the Prompt Processing config.
+
 Deleting Old Services
 ^^^^^^^^^^^^^^^^^^^^^
 

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -417,3 +417,5 @@ def main():
 
 if __name__ == "__main__":
     main()
+else:
+    _log.info("Worker ready to handle requests.")

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -410,6 +410,8 @@ def server_error(e) -> Tuple[str, int]:
 
 
 def main():
+    # This function is only called in test environments. Container
+    # deployments call `app()` through Gunicorn.
     app.run(host="127.0.0.1", port=8080, debug=True)
 
 

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -144,7 +144,8 @@ def _get_sasquatch_dispatcher():
     url = os.environ.get("SASQUATCH_URL", "")
     if not url:
         return None
-    return SasquatchDispatcher(url=url, token="", namespace="lsst.prompt")
+    token = os.environ.get("SASQUATCH_TOKEN", "")
+    return SasquatchDispatcher(url=url, token=token, namespace="lsst.prompt")
 
 
 # Offset used to define exposures' day_obs value.

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -49,7 +49,7 @@ import lsst.analysis.tools
 from .config import PipelinesConfig
 from .exception import NonRetriableError
 from .visit import FannedOutVisit
-from .timer import time_this_to_bundle
+from .timer import enforce_schema, time_this_to_bundle
 
 _log = logging.getLogger("lsst." + __name__)
 _log.setLevel(logging.DEBUG)
@@ -434,6 +434,12 @@ class MiddlewareInterface:
                                 [self._get_template_collection(),
                                  self.instrument.makeDefaultRawIngestRunName(),
                                  ])
+
+        # IMPORTANT: do not remove or rename entries in this list. New entries can be added as needed.
+        enforce_schema(bundle, {action_id: ["prep_butlerTotalTime",
+                                            "prep_butlerSearchTime",
+                                            "prep_butlerTransferTime",
+                                            ]})
 
     def _get_template_collection(self):
         """Get the collection name for templates

--- a/python/activator/timer.py
+++ b/python/activator/timer.py
@@ -1,0 +1,53 @@
+# This file is part of prompt_processing.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = ["time_this_to_bundle"]
+
+
+from contextlib import contextmanager
+
+import lsst.verify
+
+
+# This is a temporary workaround for the difficulty of handling timing metrics
+# in analysis_tools. It will be removed once we have a fully compliant solution
+# in place.
+@contextmanager
+def time_this_to_bundle(bundle, action_id, metric):
+    """Time the enclosed block and record it as a measurement in a
+    MetricMeasurementBundle.
+
+    Parameters
+    ----------
+    bundle : `lsst.analysis.tools.interfaces.MetricMeasurementBundle`
+        The bundle in which to store the measurement.
+    action_id : `str`
+        The analysis_tools-style "action" to declare for these metrics.
+    metric : `str` or `lsst.verify.Name`
+        The fully-qualified name for the metric.
+    """
+    metric_obj = lsst.verify.Metric(metric, f"Automatic timing for {metric}", "s")
+    meas = lsst.verify.Measurement(metric_obj)
+    try:
+        with lsst.verify.timer.time_this_to_measurement(meas):
+            yield
+    finally:
+        bundle.setdefault(action_id, []).append(meas)

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -46,7 +46,8 @@ import lsst.resources
 from activator.config import PipelinesConfig
 from activator.exception import NonRetriableError
 from activator.visit import FannedOutVisit
-from activator.middleware_interface import get_central_butler, make_local_repo, MiddlewareInterface, \
+from activator.middleware_interface import get_central_butler, make_local_repo, _get_sasquatch_dispatcher, \
+    MiddlewareInterface, \
     _filter_datasets, _prepend_collection, _remove_from_chain, _filter_calibs_by_date, _MissingDatasetError
 
 # The short name of the instrument used in the test repo.
@@ -661,6 +662,13 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         """
         return lsst.daf.butler.DatasetRef(registry.getDatasetType(dtype), data_id, run=run) \
             .expanded(registry.expandDataId(data_id))
+
+    def test_get_sasquatch_dispatcher(self):
+        self.assertIsNone(_get_sasquatch_dispatcher())
+        with unittest.mock.patch.dict(os.environ,
+                                      {"SASQUATCH_URL": "https://localhost/dummy",
+                                       }):
+            self.assertIsNotNone(_get_sasquatch_dispatcher())
 
     def test_filter_datasets(self):
         """Test that _filter_datasets provides the correct values.

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -1,0 +1,70 @@
+# This file is part of prompt_processing.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+import time
+import unittest
+
+import astropy.units as u
+
+import lsst.verify
+import lsst.analysis.tools
+
+from activator.timer import time_this_to_bundle
+
+
+class TimeThisTest(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.bundle = lsst.analysis.tools.interfaces.MetricMeasurementBundle(dataset_identifier="unittest")
+
+    def test_basic(self):
+        duration = 0.2
+        with time_this_to_bundle(self.bundle, "testAction", "basicMetric"):
+            time.sleep(duration)
+
+        self.assertEqual(self.bundle.keys(), {"testAction"})
+        self.assertEqual(len(self.bundle["testAction"]), 1)
+        meas = self.bundle["testAction"][0]
+
+        self.assertEqual(meas.metric_name, lsst.verify.Name(metric="basicMetric"))
+        self.assertIsNotNone(meas.quantity)
+        self.assertGreater(meas.quantity, duration * u.second)
+        self.assertLess(meas.quantity, 2 * duration * u.second)
+
+    def test_exception(self):
+        duration = 0.2
+        try:
+            with time_this_to_bundle(self.bundle, "testAction", "prompt_processing.resilientMetric"):
+                time.sleep(duration)
+                raise RuntimeError("I take exception to that!")
+        except RuntimeError:
+            pass
+
+        self.assertEqual(self.bundle.keys(), {"testAction"})
+        self.assertEqual(len(self.bundle["testAction"]), 1)
+        meas = self.bundle["testAction"][0]
+
+        self.assertEqual(meas.metric_name,
+                         lsst.verify.Name(package="prompt_processing", metric="resilientMetric"))
+        self.assertIsNotNone(meas.quantity)
+        self.assertGreater(meas.quantity, duration * u.second)
+        self.assertLess(meas.quantity, 2 * duration * u.second)

--- a/tests/test_timer.py
+++ b/tests/test_timer.py
@@ -28,7 +28,7 @@ import astropy.units as u
 import lsst.verify
 import lsst.analysis.tools
 
-from activator.timer import time_this_to_bundle
+from activator.timer import time_this_to_bundle, enforce_schema
 
 
 class TimeThisTest(unittest.TestCase):
@@ -68,3 +68,79 @@ class TimeThisTest(unittest.TestCase):
         self.assertIsNotNone(meas.quantity)
         self.assertGreater(meas.quantity, duration * u.second)
         self.assertLess(meas.quantity, 2 * duration * u.second)
+
+
+class EnforceSchemaTest(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.bundle = lsst.analysis.tools.interfaces.MetricMeasurementBundle(dataset_identifier="unittest")
+        self.bundle.setdefault("action1", []).append(
+            lsst.verify.Measurement("testMetric1", 42 * u.dimensionless_unscaled))
+        self.bundle.setdefault("action1", []).append(
+            lsst.verify.Measurement("testMetric2", 2.7 * u.meter / u.second))
+        self.bundle.setdefault("action2", []).append(
+            lsst.verify.Measurement(lsst.verify.Name(package="test", metric="testMetric3"), 5 * u.second))
+        self.bundle.setdefault("action3", [])
+
+    @staticmethod
+    def _get_names(meas_list):
+        return sorted(str(m.metric_name) for m in meas_list)
+
+    def test_match(self):
+        enforce_schema(self.bundle, {"action1": ["testMetric1", "testMetric2"],
+                                     "action2": ["test.testMetric3"],
+                                     })
+
+        # action3 ignored because no actual measurements
+        self.assertEqual(self.bundle.keys(), {"action1", "action2", "action3"})
+        self.assertEqual(self._get_names(self.bundle["action1"]), ["testMetric1", "testMetric2"])
+        self.assertEqual(self._get_names(self.bundle["action2"]), ["test.testMetric3"])
+        self.assertEqual(self._get_names(self.bundle["action3"]), [])
+
+    def test_extra_metrics(self):
+        enforce_schema(self.bundle, {"action1": ["testMetric1", "testMetric2", "testMetric2b"],
+                                     "action2": ["test.testMetric3"],
+                                     "action3": ["testMetric4"],
+                                     "action4": ["testMetric5", "testMetric6"],
+                                     })
+
+        self.assertEqual(self.bundle.keys(), {"action1", "action2", "action3", "action4"})
+        self.assertEqual(self._get_names(self.bundle["action1"]),
+                         ["testMetric1", "testMetric2", "testMetric2b"])
+        for meas in self.bundle["action1"]:
+            if meas.metric_name == lsst.verify.Name(metric="testMetric2b"):
+                self.assertIsNone(meas.quantity)
+            else:
+                self.assertIsNotNone(meas.quantity)
+        self.assertEqual(self._get_names(self.bundle["action2"]), ["test.testMetric3"])
+        for meas in self.bundle["action2"]:
+            self.assertIsNotNone(meas.quantity)
+        self.assertEqual(self._get_names(self.bundle["action3"]), ["testMetric4"])
+        for meas in self.bundle["action3"]:
+            self.assertIsNone(meas.quantity)
+        self.assertEqual(self._get_names(self.bundle["action4"]), ["testMetric5", "testMetric6"])
+        for meas in self.bundle["action4"]:
+            self.assertIsNone(meas.quantity)
+
+    def test_missing_metrics(self):
+        with self.assertRaises(RuntimeError):
+            enforce_schema(self.bundle, {"action1": ["testMetric1"],
+                                         "action2": ["test.testMetric3"],
+                                         })
+
+    def test_missing_actions(self):
+        with self.assertRaises(RuntimeError):
+            enforce_schema(self.bundle, {"action1": ["testMetric1", "testMetric2"],
+                                         })
+
+    def test_empty(self):
+        enforce_schema(self.bundle, {"action1": ["testMetric1", "testMetric2"],
+                                     "action2": ["test.testMetric3"],
+                                     "action4": [],
+                                     })
+
+        # action3 and action4 ignored because no actual measurements
+        self.assertEqual(self.bundle.keys(), {"action1", "action2", "action3"})
+        self.assertEqual(self._get_names(self.bundle["action1"]), ["testMetric1", "testMetric2"])
+        self.assertEqual(self._get_names(self.bundle["action2"]), ["test.testMetric3"])
+        self.assertEqual(self._get_names(self.bundle["action3"]), [])

--- a/ups/prompt_processing.table
+++ b/ups/prompt_processing.table
@@ -11,12 +11,14 @@ setupRequired(ap_pipe)
 setupRequired(obs_lsst)
 
 # Used by middleware_interface
+setupRequired(analysis_tools)
 setupRequired(daf_butler)
 setupRequired(ctrl_mpexec)
 setupRequired(geom)
 setupRequired(meas_algorithms)
 setupRequired(obs_base)
 setupRequired(pipe_base)
+setupRequired(verify)
 
 # used by tests
 setupRequired(obs_decam)


### PR DESCRIPTION
This PR adds two timing frameworks to Prompt Processing. The first, based on the logger, is flexible and easy to modify, but makes it hard to track long-term changes. The second, based on a hybrid of `lsst.verify` and `analysis_tools`, allows upload of timing metrics to Sasquatch, but individual metrics must be added and removed with care.