### PR TITLE
DM-41713: Many calibs (bias/flat/dark) preloaded in LATISS testing

### DIFF
--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -37,7 +37,7 @@ from lsst.resources import ResourcePath
 import lsst.afw.cameraGeom
 import lsst.ctrl.mpexec
 from lsst.ctrl.mpexec import SeparablePipelineExecutor, SingleQuantumExecutor, MPGraphExecutor
-from lsst.daf.butler import Butler, CollectionType
+from lsst.daf.butler import Butler, CollectionType, Timespan
 import lsst.dax.apdb
 import lsst.geom
 from lsst.meas.algorithms.htmIndexer import HtmIndexer
@@ -1188,28 +1188,24 @@ def _filter_calibs_by_date(butler: Butler,
     Returns
     -------
     filtered_calibs : iterable [`lsst.daf.butler.DatasetRef`]
-        The subset of ``unfiltered_calibs`` that is valid on ``date``.
+        The datasets in ``unfiltered_calibs`` that are valid on ``date``. Not
+        guaranteed to be the same `~lsst.daf.butler.DatasetRef` objects passesd
+        to ``unfiltered_calibs``, but guaranteed to be fully expanded.
     """
-    dataset_types = {ref.datasetType for ref in unfiltered_calibs}
-    associations = {}
-    for dataset_type in dataset_types:
-        associations.update(
-            (a.ref, a) for a in butler.registry.queryDatasetAssociations(
-                dataset_type, collections, collectionTypes={CollectionType.CALIBRATION}, flattenChains=True
-            )
-        )
-
-    t = astropy.time.Time(date, scale='utc')
+    t = Timespan.fromInstant(astropy.time.Time(date, scale='utc'))
     _log_trace.debug("Looking up calibs for %s in %s.", t, collections)
-    # DatasetAssociation.timespan guaranteed not None
-    filtered_calibs = []
+    filtered_calibs = set()
     for ref in unfiltered_calibs:
-        if ref in associations:
-            if associations[ref].timespan.contains(t):
-                filtered_calibs.append(ref)
-                _log_trace.debug("%s (valid over %s) matches %s.", ref, associations[ref].timespan, t)
-            else:
-                _log_trace.debug("%s (valid over %s) does not match %s.", ref, associations[ref].timespan, t)
+        # Use find_dataset to simultaneously filter by validity and chain order
+        found_ref = butler.find_dataset(ref.datasetType,
+                                        ref.dataId,
+                                        collections=collections,
+                                        timespan=t,
+                                        dimension_records=True,
+                                        )
+        if found_ref:
+            filtered_calibs.add(found_ref)
+            _log_trace.debug("%s matches %s.", ref, t)
         else:
-            _log_trace.debug("No calib associations for %s.", ref)
+            _log_trace.debug("%s does not match %s.", ref, t)
     return filtered_calibs


### PR DESCRIPTION
This PR replaces our first call to `queryDatasetAssociations` with a much faster loop over individual datasets. We still need the _second_ call to `queryDatasetAssociations`, which provides the information we need to recertify the calibs we've preloaded (see [DM-41915](https://jira.lsstcorp.org/browse/DM-41915)), but that call will be skipped if calib preload becomes a no-op.