### PR TITLE
DM-42227: Switch from datetime to astropy.time in MiddlewareInterface

### DIFF
--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -22,7 +22,6 @@
 __all__ = ["get_central_butler", "make_local_repo", "MiddlewareInterface"]
 
 import collections.abc
-import datetime
 import hashlib
 import itertools
 import logging
@@ -128,8 +127,8 @@ def make_local_repo(local_storage: str, central_butler: Butler, instrument: str)
     return repo_dir
 
 
-# Time zone used to define exposures' day_obs value.
-_DAY_OBS_TZ = datetime.timezone(datetime.timedelta(hours=-12), name="day_obs")
+# Offset used to define exposures' day_obs value.
+_DAY_OBS_DELTA = astropy.time.TimeDelta(-12.0 * astropy.units.hour, scale="tai")
 
 
 class MiddlewareInterface:
@@ -221,7 +220,7 @@ class MiddlewareInterface:
         self.instrument = lsst.obs.base.Instrument.from_string(visit.instrument, central_butler.registry)
         self.pipelines = pipelines
 
-        self._day_obs = datetime.datetime.now(_DAY_OBS_TZ).strftime("%Y-%m-%d")
+        self._day_obs = (astropy.time.Time.now() + _DAY_OBS_DELTA).tai.to_value("iso", "date")
 
         self._init_local_butler(local_repo, [self.instrument.makeUmbrellaCollectionName()], None)
         self._prep_collections()

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -625,7 +625,7 @@ class MiddlewareInterface:
 
     def _get_init_output_run(self,
                              pipeline_file: str,
-                             date: datetime.date | None = None) -> str:
+                             date: datetime.date) -> str:
         """Generate a deterministic init-output collection name that avoids
         configuration conflicts.
 
@@ -633,24 +633,21 @@ class MiddlewareInterface:
         ----------
         pipeline_file : `str`
             The pipeline file that the run will be used for.
-        date : `datetime.date`, optional
-            Date of the processing run (not observation!), defaults to the
-            day_obs this method was called.
+        date : `datetime.date`
+            Date of the processing run (not observation!).
 
         Returns
         -------
         run : `str`
             The run in which to place pipeline init-outputs.
         """
-        if date is None:
-            date = datetime.datetime.now(_DAY_OBS_TZ)
         # Current executor requires that init-outputs be in the same run as
         # outputs. This can be changed once DM-36162 is done.
         return self._get_output_run(pipeline_file, date)
 
     def _get_output_run(self,
                         pipeline_file: str,
-                        date: datetime.date | None = None) -> str:
+                        date: datetime.date) -> str:
         """Generate a deterministic collection name that avoids version or
         provenance conflicts.
 
@@ -658,17 +655,14 @@ class MiddlewareInterface:
         ----------
         pipeline_file : `str`
             The pipeline file that the run will be used for.
-        date : `datetime.date`, optional
-            Date of the processing run (not observation!), defaults to the
-            day_obs this method was called.
+        date : `datetime.date`
+            Date of the processing run (not observation!).
 
         Returns
         -------
         run : `str`
             The run in which to place processing outputs.
         """
-        if date is None:
-            date = datetime.datetime.now(_DAY_OBS_TZ)
         pipeline_name, _ = os.path.splitext(os.path.basename(pipeline_file))
         # Order optimized for S3 bucket -- filter out as many files as soon as possible.
         return self.instrument.makeCollectionName(

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -221,8 +221,7 @@ class MiddlewareInterface:
         self.instrument = lsst.obs.base.Instrument.from_string(visit.instrument, central_butler.registry)
         self.pipelines = pipelines
 
-        # Guard against a processing run starting on one day and ending the next.
-        self._day_obs = datetime.datetime.now(_DAY_OBS_TZ)
+        self._day_obs = datetime.datetime.now(_DAY_OBS_TZ).strftime("%Y-%m-%d")
 
         self._init_local_butler(local_repo, [self.instrument.makeUmbrellaCollectionName()], None)
         self._prep_collections()
@@ -625,7 +624,7 @@ class MiddlewareInterface:
 
     def _get_init_output_run(self,
                              pipeline_file: str,
-                             date: datetime.date) -> str:
+                             date: str) -> str:
         """Generate a deterministic init-output collection name that avoids
         configuration conflicts.
 
@@ -633,7 +632,7 @@ class MiddlewareInterface:
         ----------
         pipeline_file : `str`
             The pipeline file that the run will be used for.
-        date : `datetime.date`
+        date : `str`
             Date of the processing run (not observation!).
 
         Returns
@@ -647,7 +646,7 @@ class MiddlewareInterface:
 
     def _get_output_run(self,
                         pipeline_file: str,
-                        date: datetime.date) -> str:
+                        date: str) -> str:
         """Generate a deterministic collection name that avoids version or
         provenance conflicts.
 
@@ -655,7 +654,7 @@ class MiddlewareInterface:
         ----------
         pipeline_file : `str`
             The pipeline file that the run will be used for.
-        date : `datetime.date`
+        date : `str`
             Date of the processing run (not observation!).
 
         Returns
@@ -666,7 +665,7 @@ class MiddlewareInterface:
         pipeline_name, _ = os.path.splitext(os.path.basename(pipeline_file))
         # Order optimized for S3 bucket -- filter out as many files as soon as possible.
         return self.instrument.makeCollectionName(
-            "prompt", f"output-{date:%Y-%m-%d}", pipeline_name, self._deployment)
+            "prompt", f"output-{date}", pipeline_name, self._deployment)
 
     def _prep_collections(self):
         """Pre-register output collections in advance of running the pipeline.

--- a/python/tester/upload.py
+++ b/python/tester/upload.py
@@ -20,7 +20,6 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import dataclasses
-import datetime
 import itertools
 import json
 import logging
@@ -30,6 +29,7 @@ import sys
 import tempfile
 import time
 
+import astropy.time
 import boto3
 from botocore.handlers import validate_bucket_name
 
@@ -290,7 +290,7 @@ def get_samples_lsst(bucket, instrument):
             dome=FannedOutVisit.Dome.OPEN,
             duration=float(EXPOSURE_INTERVAL+SLEW_INTERVAL),
             totalCheckpoints=1,
-            private_sndStamp=datetime.datetime.fromisoformat(md["DATE-BEG"]).timestamp(),
+            private_sndStamp=astropy.time.Time(md["DATE-BEG"], format="isot", scale="tai").unix_tai,
         )
         _log.debug(f"File {blob.key} parsed as visit {visit} and registered as group {md['GROUPID']}.")
         result[md["GROUPID"]] = {0: {visit: blob}}

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -598,17 +598,11 @@ class MiddlewareInterfaceTest(unittest.TestCase):
 
     def test_get_output_run(self):
         filename = "ApPipe.yaml"
-        for date in [datetime.date.today(), datetime.datetime.today()]:
-            out_run = self.interface._get_output_run(filename, date)
-            self.assertEqual(out_run,
-                             f"{instname}/prompt/output-{date.year:04d}-{date.month:02d}-{date.day:02d}"
-                             "/ApPipe/prompt-proto-service-042"
-                             )
-            init_run = self.interface._get_init_output_run(filename, date)
-            self.assertEqual(init_run,
-                             f"{instname}/prompt/output-{date.year:04d}-{date.month:02d}-{date.day:02d}"
-                             "/ApPipe/prompt-proto-service-042"
-                             )
+        date = "2023-01-22"
+        out_run = self.interface._get_output_run(filename, date)
+        self.assertEqual(out_run, f"{instname}/prompt/output-2023-01-22/ApPipe/prompt-proto-service-042")
+        init_run = self.interface._get_init_output_run(filename, date)
+        self.assertEqual(init_run, f"{instname}/prompt/output-2023-01-22/ApPipe/prompt-proto-service-042")
 
     def _assert_in_collection(self, butler, collection, dataset_type, data_id):
         # Pass iff any dataset matches the query, no need to check them all.

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -610,26 +610,6 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                              "/ApPipe/prompt-proto-service-042"
                              )
 
-    def test_get_output_run_default(self):
-        # Workaround for mocking builtin class; see
-        # https://williambert.online/2011/07/how-to-unit-testing-in-django-with-mocking-and-patching/
-        class MockDatetime(datetime.datetime):
-            @classmethod
-            def now(cls, tz=None):
-                # This time will be the same day in CLT/CLST, but the previous day in day_obs.
-                utc = datetime.datetime(2023, 3, 15, 5, 42, 3, tzinfo=datetime.timezone.utc)
-                if tz:
-                    return utc.astimezone(tz)
-                else:
-                    return utc.replace(tzinfo=None)
-
-        filename = "ApPipe.yaml"
-        with unittest.mock.patch("datetime.datetime", MockDatetime):
-            out_run = self.interface._get_output_run(filename)
-            self.assertIn("output-2023-03-14", out_run)
-            init_run = self.interface._get_init_output_run(filename)
-            self.assertIn("output-2023-03-14", init_run)
-
     def _assert_in_collection(self, butler, collection, dataset_type, data_id):
         # Pass iff any dataset matches the query, no need to check them all.
         for dataset in butler.registry.queryDatasets(dataset_type, collections=collection, dataId=data_id):
@@ -662,7 +642,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         cat = lsst.afw.table.SourceCatalog()
         raw_collection = self.interface.instrument.makeDefaultRawIngestRunName()
         butler.registry.registerCollection(raw_collection, CollectionType.RUN)
-        out_collection = self.interface._get_output_run("ApPipe.yaml")
+        out_collection = self.interface._get_output_run("ApPipe.yaml", self.interface._day_obs)
         butler.registry.registerCollection(out_collection, CollectionType.RUN)
         chain = "generic-chain"
         butler.registry.registerCollection(chain, CollectionType.CHAINED)

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -117,13 +117,6 @@ class MiddlewareInterfaceTest(unittest.TestCase):
     """Test the MiddlewareInterface class with faked data.
     """
     def setUp(self):
-        env_patcher = unittest.mock.patch.dict(os.environ,
-                                               {"URL_APDB": "postgresql://localhost/postgres",
-                                                "K_REVISION": "prompt-proto-service-042",
-                                                })
-        env_patcher.start()
-        self.addCleanup(env_patcher.stop)
-
         self.data_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data")
         self.central_repo = os.path.join(self.data_dir, "central_repo")
         self.umbrella = f"{instname}/defaults"
@@ -133,6 +126,13 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                                      inferDefaults=False)
         self.input_data = os.path.join(self.data_dir, "input_data")
         self.local_repo = make_local_repo(tempfile.gettempdir(), self.central_butler, instname)
+
+        env_patcher = unittest.mock.patch.dict(os.environ,
+                                               {"URL_APDB": f"sqlite:///{self.local_repo.name}/apdb.db",
+                                                "K_REVISION": "prompt-proto-service-042",
+                                                })
+        env_patcher.start()
+        self.addCleanup(env_patcher.stop)
 
         # coordinates from DECam data in ap_verify_ci_hits2015 for visit 411371
         ra = 155.4702849608958
@@ -869,13 +869,6 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
             central_butler.import_(directory=data_repo, filename=export_file.name, transfer="auto")
 
     def setUp(self):
-        env_patcher = unittest.mock.patch.dict(os.environ,
-                                               {"URL_APDB": "postgresql://localhost/postgres",
-                                                "K_REVISION": "prompt-proto-service-042",
-                                                })
-        env_patcher.start()
-        self.addCleanup(env_patcher.stop)
-
         self._create_copied_repo()
         central_butler = Butler(self.central_repo.name,
                                 instrument=instname,
@@ -891,6 +884,13 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
         # getting garbage-collected.
         self.addCleanup(tempfile.TemporaryDirectory.cleanup, local_repo)
         self.addCleanup(tempfile.TemporaryDirectory.cleanup, second_local_repo)
+
+        env_patcher = unittest.mock.patch.dict(os.environ,
+                                               {"URL_APDB": f"sqlite:///{local_repo.name}/apdb.db",
+                                                "K_REVISION": "prompt-proto-service-042",
+                                                })
+        env_patcher.start()
+        self.addCleanup(env_patcher.stop)
 
         # coordinates from DECam data in ap_verify_ci_hits2015 for visit 411371
         ra = 155.4702849608958

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -29,6 +29,7 @@ import unittest.mock
 import warnings
 
 import astropy.coordinates
+import astropy.time
 import astropy.units as u
 import psycopg2
 
@@ -791,7 +792,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         all_calibs = list(self.central_butler.registry.queryDatasets("cpBias"))
         early_calibs = list(_filter_calibs_by_date(
             self.central_butler, "DECam/calib", all_calibs,
-            datetime.datetime(2015, 2, 26, tzinfo=datetime.timezone.utc)
+            astropy.time.Time("2015-02-26 00:00:00", scale="utc")
         ))
         self.assertEqual(len(early_calibs), 4)
         for calib in early_calibs:
@@ -802,7 +803,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         all_calibs = list(self.central_butler.registry.queryDatasets("cpFlat"))
         late_calibs = list(_filter_calibs_by_date(
             self.central_butler, "DECam/calib", all_calibs,
-            datetime.datetime(2015, 3, 16, tzinfo=datetime.timezone.utc)
+            astropy.time.Time("2015-03-16 00:00:00", scale="utc")
         ))
         self.assertEqual(len(late_calibs), 4)
         for calib in late_calibs:
@@ -816,7 +817,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
             warnings.simplefilter("ignore", category=astropy.utils.exceptions.ErfaWarning)
             future_calibs = list(_filter_calibs_by_date(
                 self.central_butler, "DECam/calib", all_calibs,
-                datetime.datetime(2050, 1, 1, tzinfo=datetime.timezone.utc)
+                astropy.time.Time("2050-01-01 00:00:00", scale="utc")
             ))
         self.assertEqual(len(future_calibs), 0)
 
@@ -825,14 +826,14 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         all_calibs = set(self.central_butler.registry.queryDatasets(["camera", "crosstalk"]))
         valid_calibs = set(_filter_calibs_by_date(
             self.central_butler, "DECam/calib", all_calibs,
-            datetime.datetime(2015, 3, 15, tzinfo=datetime.timezone.utc)
+            astropy.time.Time("2015-03-15 00:00:00", scale="utc")
         ))
         self.assertEqual(valid_calibs, all_calibs)
 
     def test_filter_calibs_by_date_empty(self):
         valid_calibs = set(_filter_calibs_by_date(
             self.central_butler, "DECam/calib", [],
-            datetime.datetime(2015, 3, 15, tzinfo=datetime.timezone.utc)
+            astropy.time.Time("2015-03-15 00:00:00", scale="utc")
         ))
         self.assertEqual(len(valid_calibs), 0)
 

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -116,23 +116,14 @@ def fake_file_data(filename, dimensions, instrument, visit):
 class MiddlewareInterfaceTest(unittest.TestCase):
     """Test the MiddlewareInterface class with faked data.
     """
-    @classmethod
-    def setUpClass(cls):
-        cls.env_patcher = unittest.mock.patch.dict(os.environ,
-                                                   {"URL_APDB": "postgresql://localhost/postgres",
-                                                    "K_REVISION": "prompt-proto-service-042",
-                                                    })
-        cls.env_patcher.start()
-
-        super().setUpClass()
-
-    @classmethod
-    def tearDownClass(cls):
-        super().tearDownClass()
-
-        cls.env_patcher.stop()
-
     def setUp(self):
+        env_patcher = unittest.mock.patch.dict(os.environ,
+                                               {"URL_APDB": "postgresql://localhost/postgres",
+                                                "K_REVISION": "prompt-proto-service-042",
+                                                })
+        env_patcher.start()
+        self.addCleanup(env_patcher.stop)
+
         self.data_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data")
         self.central_repo = os.path.join(self.data_dir, "central_repo")
         self.umbrella = f"{instname}/defaults"
@@ -853,22 +844,6 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
     setup takes longer than for MiddlewareInterfaceTest, so it should be
     used sparingly.
     """
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-
-        cls.env_patcher = unittest.mock.patch.dict(os.environ,
-                                                   {"URL_APDB": "postgresql://localhost/postgres",
-                                                    "K_REVISION": "prompt-proto-service-042",
-                                                    })
-        cls.env_patcher.start()
-
-    @classmethod
-    def tearDownClass(cls):
-        super().tearDownClass()
-
-        cls.env_patcher.stop()
-
     def _create_copied_repo(self):
         """Create a fresh repository that's a copy of the test data.
 
@@ -894,6 +869,13 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
             central_butler.import_(directory=data_repo, filename=export_file.name, transfer="auto")
 
     def setUp(self):
+        env_patcher = unittest.mock.patch.dict(os.environ,
+                                               {"URL_APDB": "postgresql://localhost/postgres",
+                                                "K_REVISION": "prompt-proto-service-042",
+                                                })
+        env_patcher.start()
+        self.addCleanup(env_patcher.stop)
+
         self._create_copied_repo()
         central_butler = Butler(self.central_repo.name,
                                 instrument=instname,


### PR DESCRIPTION
This PR removes the use of `datetime` in `MiddlewareInterface` in favor of `astropy.time`, though some unit tests still use `datetime` as the oracle. It also fixes a bug in our tests that was exposed by lsst/dax_apdb#41.