### PR TITLE
DM-33453: Update pipeline references in response to RFC-775.

### DIFF
--- a/pipelines/HSC/ApPipe.yaml
+++ b/pipelines/HSC/ApPipe.yaml
@@ -1,7 +1,7 @@
 description: End to end Alert Production pipeline specialized for HSC-RC2
 
 imports:
-  - location: $AP_PIPE_DIR/pipelines/HyperSuprimeCam/ApPipe.yaml
+  - location: $AP_PIPE_DIR/pipelines/HSC/ApPipe.yaml
     exclude:
       # TODO: container does not yet support R/B analysis.
       - rbClassify

--- a/tests/data/ApPipe.yaml
+++ b/tests/data/ApPipe.yaml
@@ -13,7 +13,7 @@ description: End to end Alert Production pipeline specialized for HiTS-2015
 # -c diaPipe:apdb.connection_timeout: 240
 
 imports:
-  - location: $AP_PIPE_DIR/pipelines/DarkEnergyCamera/ApPipe.yaml
+  - location: $AP_PIPE_DIR/pipelines/DECam/ApPipe.yaml
 parameters:
   # Use dataset's specific templates
   coaddName: goodSeeing


### PR DESCRIPTION
Changed `HyperSuprimeCam` to `HSC` and `DarkEnergyCamera` to `DECam` in response to RFC-775.