### PR TITLE
DM-43200: Prompt processing unit tests don't work with group dimensions

### DIFF
--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -855,7 +855,10 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
                 export.saveDatasets(data_butler.registry.queryDatasets(..., collections=...))
                 for collection in data_butler.registry.queryCollections():
                     export.saveCollection(collection)
-            central_butler = Butler(Butler.makeRepo(self.central_repo.name), writeable=True)
+            dimension_config = data_butler.dimensions.dimensionConfig
+            central_butler = Butler(Butler.makeRepo(self.central_repo.name, dimensionConfig=dimension_config),
+                                    writeable=True,
+                                    )
             central_butler.import_(directory=data_repo, filename=export_file.name, transfer="auto")
 
     def setUp(self):


### PR DESCRIPTION
This PR fixes a big in the setup of `MiddlewareInterfaceWriteableTest` that caused it to create a central repo with the latest Butler dimensions-config version rather than the one associated with the test data. The fix makes the test code forward-compatible.