### PR TITLE
DM-43182: Prompt Processing GitHub Actions don't account for test-only PRs

### DIFF
--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -36,9 +36,9 @@ jobs:
       STACK_TAG: ${{ inputs.stackTag }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-service.yml
+++ b/.github/workflows/build-service.yml
@@ -51,11 +51,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Fix permissions
         run: chmod -R a+rwX $GITHUB_WORKSPACE
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -87,9 +87,9 @@ jobs:
       BASE_TAG: ${{ matrix.baseTag }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/build-service.yml
+++ b/.github/workflows/build-service.yml
@@ -8,12 +8,14 @@ on:
       - '.github/workflows/build-service.yml'
       - 'pipelines/**'
       - 'python/activator/**'
+      - 'tests/**'
       - 'Dockerfile'
   pull_request:
     paths:
       - '.github/workflows/build-service.yml'
       - 'pipelines/**'
       - 'python/activator/**'
+      - 'tests/**'
       - 'Dockerfile'
   workflow_dispatch:
 

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -13,7 +13,14 @@ name: Release CI
       - "u/**"
     tags:
       - "*"
-  pull_request: {}
+  pull_request:
+    # Matches build-service.yml
+    paths:
+      - '.github/workflows/ci-release.yaml'
+      - 'pipelines/**'
+      - 'python/activator/**'
+      - 'tests/**'
+      - 'Dockerfile'
 
 env:
   # Base tag to run tests against.

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -35,13 +35,13 @@ jobs:
       || startsWith(github.head_ref, 'tickets/')
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Fix permissions
         run: chmod -R a+rwX $GITHUB_WORKSPACE
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
This PR modifies the Prompt Processing build actions to trigger when the unit tests are updated, to confirm that the new tests pass. It also places the "Release CI" workflow under the same restrictions as "Build and test service", so that it does not trigger on non-code changes.

Unfortunately, since both workflows trigger on changes to the workflow, it's not possible to test these changes on this PR.