### PR TITLE
DM-43205: Calibs fail to locally certify in Prompt Processing

### DIFF
--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -57,6 +57,8 @@ _log.setLevel(logging.DEBUG)
 # See https://developer.lsst.io/stack/logging.html#logger-trace-verbosity
 _log_trace = logging.getLogger("TRACE1.lsst." + __name__)
 _log_trace.setLevel(logging.CRITICAL)  # Turn off by default.
+_log_trace3 = logging.getLogger("TRACE3.lsst." + __name__)
+_log_trace3.setLevel(logging.CRITICAL)  # Turn off by default.
 
 
 def get_central_butler(central_repo: str, instrument_class: str):
@@ -1236,6 +1238,7 @@ def _filter_datasets(src_repo: Butler,
         with lsst.utils.timer.time_this(_log, msg=f"_filter_datasets({formatted_args}) (known datasets)",
                                         level=logging.DEBUG):
             known_datasets = set(dest_repo.registry.queryDatasets(*args, **kwargs))
+            _log_trace.debug("Known datasets: %s", known_datasets)
     except lsst.daf.butler.registry.DataIdValueError as e:
         _log.debug("Pre-export query with args '%s' failed with %s", formatted_args, e)
         # If dimensions are invalid, then *any* such datasets are missing.
@@ -1248,6 +1251,8 @@ def _filter_datasets(src_repo: Butler,
     with lsst.utils.timer.time_this(_log, msg=f"_filter_datasets({formatted_args}) (source datasets)",
                                     level=logging.DEBUG):
         src_datasets = set(src_repo.registry.queryDatasets(*args, **kwargs).expanded())
+        # In many contexts, src_datasets is too large to print.
+        _log_trace3.debug("Source datasets: %s", src_datasets)
     if calib_date:
         src_datasets = _filter_calibs_by_date(
             src_repo,
@@ -1255,6 +1260,7 @@ def _filter_datasets(src_repo: Butler,
             src_datasets,
             calib_date,
         )
+        _log_trace.debug("Sources filtered to %s: %s", calib_date.iso, src_datasets)
     if not src_datasets:
         raise _MissingDatasetError(
             "Source repo query with args '{}' found no matches.".format(formatted_args))

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -702,6 +702,25 @@ class MiddlewareInterface:
                     present.remove(missing)
             dest.setCollectionChain(chain, present)
 
+    # VALIDITY-HACK: used only for local "latest calibs" collection
+    def _get_local_calib_collection(self, parent):
+        """Generate a name for a local-only calib collection to store mock
+        associations.
+
+        Parameters
+        ----------
+        parent : `str`
+            The chain that serves as the calib interface for the rest of
+            this class.
+
+        Returns
+        -------
+        calib_collection : `str`
+            The calibration collection name to use. This method does *not*
+            create the collection itself.
+        """
+        return f"{parent}/{self._day_obs}"
+
     def _export_calib_associations(self, calib_collection, datasets):
         """Export the associations between a set of datasets and a
         calibration collection.
@@ -721,15 +740,15 @@ class MiddlewareInterface:
         # latest calibs as of today. Already-cached calibs are still available
         # from previous collections.
         if datasets:
-            calib_daily = f"{calib_collection}/{self._day_obs}"
-            new = self.butler.registry.registerCollection(calib_daily, CollectionType.CALIBRATION)
+            calib_latest = self._get_local_calib_collection(calib_collection)
+            new = self.butler.registry.registerCollection(calib_latest, CollectionType.CALIBRATION)
             if new:
-                _prepend_collection(self.butler, calib_collection, [calib_daily])
+                _prepend_collection(self.butler, calib_collection, [calib_latest])
 
             # VALIDITY-HACK: real associations are expensive to query. Just apply
             # arbitrary ones and assume that the first collection in the chain is
             # always the best.
-            self.butler.registry.certify(calib_daily, datasets, Timespan(None, None))
+            self.butler.registry.certify(calib_latest, datasets, Timespan(None, None))
 
     @staticmethod
     def _count_by_type(refs):

--- a/tests/test_raw.py
+++ b/tests/test_raw.py
@@ -23,6 +23,7 @@ import json
 import os
 import re
 import unittest
+import warnings
 
 from lsst.resources import ResourcePath
 
@@ -107,8 +108,10 @@ class LsstBase(RawBase):
                             self.snap, self.exposure, self.filter)
         fits_path = ResourcePath(f"s3://{self.bucket}").join(path)
         json_path = fits_path.updatedExtension("json")
-        with json_path.open("w") as f:
-            json.dump(dict(GROUPID=self.group, CURINDEX=self.snap + 1), f)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", "S3 does not support flushing objects", UserWarning)
+            with json_path.open("w") as f:
+                json.dump(dict(GROUPID=self.group, CURINDEX=self.snap + 1), f)
         assert is_path_consistent(path, self.visit)
         assert get_group_id_from_oid(path) == self.group
 


### PR DESCRIPTION
This PR modifies the calib validity hack introduced on #129 to optionally purge the calib cache, preventing conflicts if two calibs are loaded on the same day. While calibs do not change mid-day in production, our integration tests (especially HSC RC2) mix a wide range of "real" observing dates in a single run, and the previous hack would break them.