### PR TITLE
DM-43317: Use prompt-service as sole package for Prompt Processing

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -23,6 +23,7 @@ name: Release CI
       - 'Dockerfile'
 
 env:
+  IMAGE_NAME: lsst-dm/prompt-service
   # Base tag to run tests against.
   BASE_TAG: "latest"
 
@@ -63,7 +64,7 @@ jobs:
       - uses: lsst-sqre/build-and-push-to-ghcr@v1
         id: build
         with:
-          image: ${{ github.repository }} # e.g. lsst-sqre/safirdemo
+          image: ${{ env.IMAGE_NAME }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - run: echo Pushed ghcr.io/${{ github.repository }}:${{ steps.build.outputs.tag }}

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -14,12 +14,9 @@ name: Release CI
     tags:
       - "*"
   pull_request:
-    # Matches build-service.yml
+    # Test changes to build process; code changes are handled by build-service.yml
     paths:
       - '.github/workflows/ci-release.yaml'
-      - 'pipelines/**'
-      - 'python/activator/**'
-      - 'tests/**'
       - 'Dockerfile'
 
 env:

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -86,7 +86,7 @@ try:
     consumer = kafka.Consumer({
         "bootstrap.servers": kafka_cluster,
         "group.id": kafka_group_id,
-        "auto.offset.reset": "largest",  # default, but make explicit
+        "auto.offset.reset": "latest",  # default, but make explicit
     })
 
     storage_client = boto3.client('s3', endpoint_url=s3_endpoint)


### PR DESCRIPTION
This PR changes the `ci-release` workflow to build to `prompt-service` instead of `prompt-processing`. It also turns off PR builds to avoid potentially confusing duplication with `prompt-service`.