### PR TITLE
DM-43394: Set up AP pipeline variant that omits forced-source loading

### DIFF
--- a/pipelines/LATISS/ApPipe-noForced.yaml
+++ b/pipelines/LATISS/ApPipe-noForced.yaml
@@ -1,0 +1,15 @@
+description: >-
+  Alert Production pipeline specialized for LATISS,
+  with forced source handling turned off
+
+# This file serves as an "emergency shutdown" for a known issue in the DIA
+# processing task. It is not intended for general use, and unlike ApPipe proper
+# will not be synced to the ap_pipe package.
+imports:
+  - location: $PROMPT_PROCESSING_DIR/pipelines/LATISS/ApPipe.yaml
+tasks:
+  diaPipe:
+    class: lsst.ap.association.DiaPipelineTask
+    config:
+      doLoadForcedSources: false  # see DM-43394
+      doRunForcedMeasurement: false  # see DM-43402

--- a/pipelines/LSSTComCamSim/ApPipe-noForced.yaml
+++ b/pipelines/LSSTComCamSim/ApPipe-noForced.yaml
@@ -1,0 +1,15 @@
+description: >-
+  Alert Production pipeline specialized for LSSTComCamSim,
+  with forced source handling turned off
+
+# This file serves as an "emergency shutdown" for a known issue in the DIA
+# processing task. It is not intended for general use, and unlike ApPipe proper
+# will not be synced to the ap_pipe package.
+imports:
+  - location: $PROMPT_PROCESSING_DIR/pipelines/LSSTComCamSim/ApPipe.yaml
+tasks:
+  diaPipe:
+    class: lsst.ap.association.DiaPipelineTask
+    config:
+      doLoadForcedSources: false  # see DM-43389
+      doRunForcedMeasurement: false  # see DM-43402

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -1044,7 +1044,7 @@ class MiddlewareInterface:
                 task_factory=factory,
             )
             try:
-                with lsst.utils.timer.time_this(_log, msg="make_quantum_graph", level=logging.DEBUG):
+                with lsst.utils.timer.time_this(_log, msg="executor.make_quantum_graph", level=logging.DEBUG):
                     qgraph = executor.make_quantum_graph(pipeline, where=where)
             except MissingDatasetTypeError as e:
                 _log.error(f"Building quantum graph for {pipeline_file} failed ", exc_info=e)
@@ -1063,8 +1063,12 @@ class MiddlewareInterface:
             executor.pre_execute_qgraph(qgraph, register_dataset_types=True, save_init_outputs=True)
             _log.info(f"Running '{pipeline._pipelineIR.description}' on {where}")
             try:
-                executor.run_pipeline(qgraph, graph_executor=self._get_graph_executor(exec_butler, factory))
-                _log.info("Pipeline successfully run.")
+                with lsst.utils.timer.time_this(_log, msg="executor.run_pipeline", level=logging.DEBUG):
+                    executor.run_pipeline(
+                        qgraph,
+                        graph_executor=self._get_graph_executor(exec_butler, factory)
+                    )
+                    _log.info("Pipeline successfully run.")
             except Exception as e:
                 state_changed = True  # better safe than sorry
                 try:


### PR DESCRIPTION
This PR adds a temporary pipeline that turns off forced source loading (and, with future changes to the pipeline, possibly forced source measurement as well). This is a configuration we may need for the Ops Rehearsal, but it is not expected to become the baseline `ApPipe`.

Because the config flag that is set here will not be available until `w_2024_12`, I have not tested the pipeline on our dev cluster. I have, however, confirmed locally that the pipeline definition is valid.

I've also piggybacked a timing improvement that may help us characterize the runtime problems that inspired the `doLoadForcedSources` config in the first place.