### PR TITLE
DM-43472: Prompt Processing version 2 not compatible with Butler dimensions-config 6

### DIFF
--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -1202,6 +1202,7 @@ class MiddlewareInterface:
             # central registry. We need to transfer our exposure/visit dimensions,
             # so handle those manually.
             for dimension in ["group",
+                              "day_obs",
                               "exposure",
                               "visit",
                               # TODO: visit_* are not needed from version 4; remove when we require v6


### PR DESCRIPTION
This PR adds a `day_obs` dimension to the fix merged on #143; for some reason the tests with that PR passed without it.