### PR TITLE
DM-43502: Prompt Processing should get expId from ingest, not file path

### DIFF
--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -43,7 +43,6 @@ from .middleware_interface import get_central_butler, make_local_repo, Middlewar
 from .raw import (
     get_prefix_from_snap,
     is_path_consistent,
-    get_exp_id_from_oid,
     get_group_id_from_oid,
 )
 from .visit import FannedOutVisit
@@ -307,9 +306,8 @@ def next_visit_handler() -> Tuple[str, int]:
                     expected_visit.detector,
                 )
                 if oid:
-                    exp_id = get_exp_id_from_oid(oid)
-                    _log.debug("Found exposure %r already present", exp_id)
-                    mwi.ingest_image(oid)
+                    _log.debug("Found object %s already present", oid)
+                    exp_id = mwi.ingest_image(oid)
                     expid_set.add(exp_id)
 
             _log.debug("Waiting for snaps...")
@@ -336,9 +334,8 @@ def next_visit_handler() -> Tuple[str, int]:
                                 _log.debug("Received %r", oid)
                                 group_id = get_group_id_from_oid(oid)
                                 if group_id == expected_visit.groupId:
-                                    exp_id = get_exp_id_from_oid(oid)
                                     # Ingest the snap
-                                    mwi.ingest_image(oid)
+                                    exp_id = mwi.ingest_image(oid)
                                     expid_set.add(exp_id)
                         except ValueError:
                             _log.error(f"Failed to match object id '{oid}'")

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -953,6 +953,11 @@ class MiddlewareInterface:
         ----------
         oid : `str`
             Identifier for incoming image, relative to the image bucket.
+
+        Returns
+        -------
+        exposure_id : `int`
+            The exposure ID of the image that was just ingested.
         """
         # TODO: consider allowing pre-existing raws, as may happen when a
         # pipeline is rerun (see DM-34141).
@@ -967,6 +972,7 @@ class MiddlewareInterface:
         # how we plan to handle exceptions in this code.
         assert len(result) == 1, "Should have ingested exactly one image."
         _log.info("Ingested one %s with dataId=%s", result[0].datasetType.name, result[0].dataId)
+        return result[0].dataId["exposure"]
 
     def _get_graph_executor(self, butler, factory):
         """Create a QuantumGraphExecutor suitable for Prompt Processing.

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -370,7 +370,8 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                                             self.next_visit)
         with unittest.mock.patch.object(self.interface.rawIngestTask, "extractMetadata") as mock:
             mock.return_value = file_data
-            self.interface.ingest_image(filename)
+            exp_id = self.interface.ingest_image(filename)
+            self.assertEqual(exp_id, int(self.next_visit.groupId))
 
             datasets = list(self.interface.butler.registry.queryDatasets('raw',
                                                                          collections=[f'{instname}/raw/all']))


### PR DESCRIPTION
This PR makes exposure ID determination more robust by sourcing it directly from the ingester.

This PR closes #140.