### PR TITLE
Add missing config override to register-dataset-types call.

### DIFF
--- a/doc/playbook.rst
+++ b/doc/playbook.rst
@@ -250,7 +250,7 @@ One raw was ingested, visit-defined, and kept in the development central repo, s
 .. code-block:: sh
 
    apdb-cli create-sql "sqlite:///apdb.db" apdb_config.py
-   pipetask run -b s3://rubin-pp-dev-users/central_repo -i LATISS/raw/all,LATISS/defaults,LATISS/templates -o u/username/collection  -d "detector=0 and instrument='LATISS' and exposure=2023082900500 and visit_system=0" -p $PROMPT_PROCESSING_DIR/pipelines/LATISS/ApPipe.yaml -c diaPipe:apdb.db_url=sqlite:///apdb.db --register-dataset-types
+   pipetask run -b s3://rubin-pp-dev-users/central_repo -i LATISS/raw/all,LATISS/defaults,LATISS/templates -o u/username/collection  -d "detector=0 and instrument='LATISS' and exposure=2023082900500 and visit_system=0" -p $PROMPT_PROCESSING_DIR/pipelines/LATISS/ApPipe.yaml -c diaPipe:apdb.db_url=sqlite:///apdb.db -c diaPipe:doPackageAlerts=False --register-dataset-types
 
 .. TODO: update pipetask call after DM-43416
 


### PR DESCRIPTION
This PR fixes an example line in the Playbook to compensate for #137, which makes the Prompt Processing pipelines impossible to run as-is from USDF.