### PR TITLE
DM-43416: Add compatibility patch for APDB configuration

### DIFF
--- a/pipelines/HSC/ApPipe.yaml
+++ b/pipelines/HSC/ApPipe.yaml
@@ -10,3 +10,4 @@ tasks:
     class: lsst.ap.association.DiaPipelineTask
     config:
       doSolarSystemAssociation: false  # No "known objects" catalog for fake visits
+      doConfigureApdb: true  # Temporary patch until DM-44096 adds external config support

--- a/pipelines/LATISS/ApPipe.yaml
+++ b/pipelines/LATISS/ApPipe.yaml
@@ -12,3 +12,4 @@ tasks:
     config:
       doPackageAlerts: True
       alertPackager.doProduceAlerts: True
+      doConfigureApdb: true  # Temporary patch until DM-44096 adds external config support

--- a/pipelines/LSSTComCamSim/ApPipe.yaml
+++ b/pipelines/LSSTComCamSim/ApPipe.yaml
@@ -12,3 +12,4 @@ tasks:
     config:
       doPackageAlerts: True
       alertPackager.doProduceAlerts: True
+      doConfigureApdb: true  # Temporary patch until DM-44096 adds external config support

--- a/tests/data/ApPipe.yaml
+++ b/tests/data/ApPipe.yaml
@@ -33,3 +33,4 @@ tasks:
     class: lsst.ap.association.DiaPipelineTask
     config:
       doSolarSystemAssociation: false
+      doConfigureApdb: true  # Temporary patch until DM-44096 adds external config support


### PR DESCRIPTION
The Prompt Processing code assumes that the pipeline is configured directly through `diaPipe.apdb`, but lsst/ap_pipe#182 makes the default be `apdb_config_url`. This patch lets Prompt Processing keep using the old system until it can support the new one.

The unit test failure is expected, since we don't have a container that includes lsst/ap_pipe#182.

It may not be necessary to actually merge this patch, if our `latest` base container is never one that contains DM-43416 but not DM-44096,