### PR TITLE
DM-43316: Use atomic chain operations where appropriate in Prompt Processing

### DIFF
--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -1458,50 +1458,6 @@ def _filter_datasets(src_repo: Butler,
     return itertools.filterfalse(lambda ref: ref in known_datasets, src_datasets)
 
 
-def _prepend_collection(butler: Butler, chain: str, new_collections: collections.abc.Iterable[str]) -> None:
-    """Add a specific collection to the front of an existing chain.
-
-    Parameters
-    ----------
-    butler : `lsst.daf.butler.Butler`
-        The butler in which the collections exist.
-    chain : `str`
-        The chained collection to prepend to.
-    new_collections : sequence [`str`]
-        The collections to prepend to ``chain``, in order.
-
-    Notes
-    -----
-    This function is not safe against concurrent modifications to ``chain``.
-    """
-    old_chain = butler.registry.getCollectionChain(chain)  # May be empty
-    butler.registry.setCollectionChain(chain, list(new_collections) + list(old_chain), flatten=False)
-
-
-def _remove_from_chain(butler: Butler, chain: str, old_collections: collections.abc.Iterable[str]) -> None:
-    """Remove a specific collection from a chain.
-
-    This function has no effect if the collection is not in the chain.
-
-    Parameters
-    ----------
-    butler : `lsst.daf.butler.Butler`
-        The butler in which the collections exist.
-    chain : `str`
-        The chained collection to remove from.
-    old_collections : iterable [`str`]
-        The collections to remove from ``chain``.
-
-    Notes
-    -----
-    This function is not safe against concurrent modifications to ``chain``.
-    """
-    contents = list(butler.registry.getCollectionChain(chain))
-    for old in set(old_collections).intersection(contents):
-        contents.remove(old)
-    butler.registry.setCollectionChain(chain, contents, flatten=False)
-
-
 def _filter_calibs_by_date(butler: Butler,
                            collections: typing.Any,
                            unfiltered_calibs: collections.abc.Collection[lsst.daf.butler.DatasetRef],

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -985,7 +985,7 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
         """
         central_butler = Butler(self.central_repo.name, writeable=True)
         central_butler.registry.registerCollection("emptyrun", CollectionType.RUN)
-        _prepend_collection(central_butler, "refcats", ["emptyrun"])
+        central_butler.collection_chains.prepend_chain("refcats", ["emptyrun"])
 
         self.interface.prep_butler()
 

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -48,7 +48,7 @@ from activator.exception import NonRetriableError
 from activator.visit import FannedOutVisit
 from activator.middleware_interface import get_central_butler, make_local_repo, _get_sasquatch_dispatcher, \
     MiddlewareInterface, \
-    _filter_datasets, _prepend_collection, _remove_from_chain, _filter_calibs_by_date, _MissingDatasetError
+    _filter_datasets, _filter_calibs_by_date, _MissingDatasetError
 
 # The short name of the instrument used in the test repo.
 instname = "DECam"
@@ -745,41 +745,6 @@ class MiddlewareInterfaceTest(unittest.TestCase):
             with self.subTest(existing=sorted(ref.dataId["detector"] for ref in existing)):
                 with self.assertRaises(_MissingDatasetError):
                     _filter_datasets(src_butler, existing_butler, "cpBias", instrument="DECam")
-
-    def test_prepend_collection(self):
-        butler = self.interface.butler
-        butler.registry.registerCollection("_prepend1", CollectionType.TAGGED)
-        butler.registry.registerCollection("_prepend2", CollectionType.TAGGED)
-        butler.registry.registerCollection("_prepend3", CollectionType.TAGGED)
-        butler.registry.registerCollection("_prepend_base", CollectionType.CHAINED)
-
-        # Empty chain.
-        self.assertEqual(list(butler.registry.getCollectionChain("_prepend_base")), [])
-        _prepend_collection(butler, "_prepend_base", ["_prepend1"])
-        self.assertEqual(list(butler.registry.getCollectionChain("_prepend_base")), ["_prepend1"])
-
-        # Non-empty chain.
-        butler.registry.setCollectionChain("_prepend_base", ["_prepend1", "_prepend2"])
-        _prepend_collection(butler, "_prepend_base", ["_prepend3"])
-        self.assertEqual(list(butler.registry.getCollectionChain("_prepend_base")),
-                         ["_prepend3", "_prepend1", "_prepend2"])
-
-    def test_remove_from_chain(self):
-        butler = self.interface.butler
-        butler.registry.registerCollection("_remove1", CollectionType.TAGGED)
-        butler.registry.registerCollection("_remove2", CollectionType.TAGGED)
-        butler.registry.registerCollection("_remove33", CollectionType.TAGGED)
-        butler.registry.registerCollection("_remove_base", CollectionType.CHAINED)
-
-        # Empty chain.
-        self.assertEqual(list(butler.registry.getCollectionChain("_remove_base")), [])
-        _remove_from_chain(butler, "_remove_base", ["_remove1"])
-        self.assertEqual(list(butler.registry.getCollectionChain("_remove_base")), [])
-
-        # Non-empty chain.
-        butler.registry.setCollectionChain("_remove_base", ["_remove1", "_remove2"])
-        _remove_from_chain(butler, "_remove_base", ["_remove2", "_remove3"])
-        self.assertEqual(list(butler.registry.getCollectionChain("_remove_base")), ["_remove1"])
 
     def test_filter_calibs_by_date_early(self):
         # _filter_calibs_by_date requires a collection, not merely an iterable


### PR DESCRIPTION
This PR replaces all but one of the read-modify-write collection operations in `MiddlewareInterface` with the new atomic methods provided by `daf.butler.ButlerCollections`. This fixes a concurrency bug introduced on #136.