### PR TITLE
DM-44096: Migrate Prompt Processing to external APDB configs

### DIFF
--- a/doc/playbook.rst
+++ b/doc/playbook.rst
@@ -497,3 +497,13 @@ To restore the APDB to a clean state, run ``apdb-cli create-sql`` with ``--drop`
 
    apdb-cli create-sql --drop --namespace="pp_apdb_lsstcomcamsim" \
        "postgresql://rubin@usdf-prompt-processing-dev.slac.stanford.edu/lsst-devl" apdb_config_lsstcomcamsim.py
+
+Checking the APDB Version
+-------------------------
+
+To identify which schema and ApdbSql version a PostgreSQL APDB is using, run, e.g.:
+
+.. code-block:: sh
+
+   psql -h usdf-prompt-processing-dev.slac.stanford.edu lsst-devl rubin \
+       -c 'select * from pp_apdb_latiss.metadata;'

--- a/doc/playbook.rst
+++ b/doc/playbook.rst
@@ -264,7 +264,7 @@ One raw was ingested, visit-defined, and kept in the development central repo, s
 .. code-block:: sh
 
    apdb-cli create-sql "sqlite:///apdb.db" apdb_config.py
-   pipetask run -b s3://rubin-pp-dev-users/central_repo -i LATISS/raw/all,LATISS/defaults,LATISS/templates -o u/username/collection  -d "detector=0 and instrument='LATISS' and exposure=2023082900500 and visit_system=0" -p $PROMPT_PROCESSING_DIR/pipelines/LATISS/ApPipe.yaml -c diaPipe:apdb.db_url=sqlite:///apdb.db -c diaPipe:doPackageAlerts=False --register-dataset-types
+   pipetask run -b s3://rubin-pp-dev-users/central_repo -i LATISS/raw/all,LATISS/defaults,LATISS/templates -o u/username/collection  -d "detector=0 and instrument='LATISS' and exposure=2023082900500 and visit_system=0" -p $PROMPT_PROCESSING_DIR/pipelines/LATISS/ApPipe.yaml -c parameters:apdb_config=apdb_config.py -c diaPipe:doPackageAlerts=False --register-dataset-types
 
 .. TODO: update pipetask call after DM-43416
 

--- a/tests/data/ApPipe.yaml
+++ b/tests/data/ApPipe.yaml
@@ -4,13 +4,6 @@ description: End to end Alert Production pipeline specialized for HiTS-2015
 # with two modifications: (1) doSolarSystemAssociation is disabled, and
 # (2) the calibrateImage.py file from this package is used. The
 # calibrateImage.py file was copied from ap_verify_ci_hits2015 too.
-#
-# NOTES
-# Remember to run make_apdb.py and use the same configs for diaPipe
-# A db_url is always required, e.g.,
-# -c diaPipe:apdb.db_url: 'sqlite:////project/user/association.db'
-# Option to specify connection_timeout for sqlite APDBs encountering lock errors, i.e.,
-# -c diaPipe:apdb.connection_timeout: 240
 
 imports:
   - location: $AP_PIPE_DIR/pipelines/DECam/ApPipe.yaml

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -137,8 +137,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         config.save(config_file.name)
 
         env_patcher = unittest.mock.patch.dict(os.environ,
-                                               {"URL_APDB": f"sqlite:///{self.local_repo.name}/apdb.db",
-                                                "CONFIG_APDB": config_file.name,
+                                               {"CONFIG_APDB": config_file.name,
                                                 "K_REVISION": "prompt-proto-service-042",
                                                 })
         env_patcher.start()
@@ -857,8 +856,7 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
         config.save(config_file.name)
 
         env_patcher = unittest.mock.patch.dict(os.environ,
-                                               {"URL_APDB": f"sqlite:///{local_repo.name}/apdb.db",
-                                                "CONFIG_APDB": config_file.name,
+                                               {"CONFIG_APDB": config_file.name,
                                                 "K_REVISION": "prompt-proto-service-042",
                                                 })
         env_patcher.start()

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -128,6 +128,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                                      inferDefaults=False)
         self.input_data = os.path.join(self.data_dir, "input_data")
         self.local_repo = make_local_repo(tempfile.gettempdir(), self.central_butler, instname)
+        self.addCleanup(self.local_repo.cleanup)  # TemporaryDirectory warns on leaks
 
         env_patcher = unittest.mock.patch.dict(os.environ,
                                                {"URL_APDB": f"sqlite:///{self.local_repo.name}/apdb.db",
@@ -163,11 +164,6 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         self.interface = MiddlewareInterface(self.central_butler, self.input_data, self.next_visit,
                                              pipelines, skymap_name, self.local_repo.name,
                                              prefix="file://")
-
-    def tearDown(self):
-        super().tearDown()
-        # TemporaryDirectory warns on leaks
-        self.local_repo.cleanup()
 
     def test_get_butler(self):
         for butler in [get_central_butler(self.central_repo, "lsst.obs.decam.DarkEnergyCamera"),


### PR DESCRIPTION
This PR replaces all internal references to `apdb.db_url` with `parameters:apdb_config`, and updates the service configuration interface accordingly. Closes #155.