### PR TITLE
DM-43948: Create region/time dataset in Prompt Processing

### DIFF
--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -1040,10 +1040,12 @@ class MiddlewareInterface:
                 pipeline = self._prep_pipeline(pipeline_file)
             except FileNotFoundError as e:
                 raise RuntimeError from e
+            preload_run = self._get_preload_run(self._day_obs)
             init_output_run = self._get_init_output_run(pipeline_file, self._day_obs)
             output_run = self._get_output_run(pipeline_file, self._day_obs)
             exec_butler = Butler(butler=self.butler,
-                                 collections=[output_run, init_output_run] + list(self.butler.collections),
+                                 collections=[output_run, init_output_run, preload_run]
+                                 + list(self.butler.collections),
                                  run=output_run)
             factory = lsst.ctrl.mpexec.TaskFactory()
             executor = SeparablePipelineExecutor(

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -285,6 +285,11 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                           full_check=True,
                           collections=preload_collection)
         )
+        self.assertTrue(
+            butler.exists('regionTimeInfo', instrument=instname, group=group, detector=detector,
+                          full_check=True,
+                          collections=preload_collection)
+        )
 
     def test_prep_butler(self):
         """Test that the butler has all necessary data for the next visit.
@@ -950,6 +955,9 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
         butler_tests.addDatasetType(self.interface.central_butler, "promptPreload_metrics",
                                     {"instrument", "group", "detector"},
                                     "MetricMeasurementBundle")
+        butler_tests.addDatasetType(self.interface.central_butler, "regionTimeInfo",
+                                    {"instrument", "group", "detector"},
+                                    "RegionTimeInfo")
         butler_tests.addDatasetType(self.interface.central_butler, "calexp",
                                     {"instrument", "visit", "detector"},
                                     "ExposureF")

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -213,7 +213,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         self.assertEqual(self.interface.rawIngestTask.config.failFast, True)
         self.assertEqual(self.interface.rawIngestTask.config.transfer, "copy")
 
-    def _check_imports(self, butler, detector, expected_shards, expected_date):
+    def _check_imports(self, butler, group, detector, expected_shards, expected_date):
         """Test that the butler has the expected supporting data.
         """
         self.assertEqual(butler.get('camera',
@@ -276,6 +276,16 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                           collections=self.umbrella)
         )
 
+        # Check that preloaded datasets have been generated
+        date = datetime.datetime.now(datetime.timezone(datetime.timedelta(hours=-12)))
+        preload_collection = f"{instname}/prompt/output-{date.year:04d}-{date.month:02d}-{date.day:02d}/" \
+                             "Preload/prompt-proto-service-042"
+        self.assertTrue(
+            butler.exists('promptPreload_metrics', instrument=instname, group=group, detector=detector,
+                          full_check=True,
+                          collections=preload_collection)
+        )
+
     def test_prep_butler(self):
         """Test that the butler has all necessary data for the next visit.
         """
@@ -286,7 +296,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         # TODO DM-34112: check these shards again with some plots, once I've
         # determined whether ci_hits2015 actually has enough shards.
         expected_shards = {157394, 157401, 157405}
-        self._check_imports(self.interface.butler, detector=56,
+        self._check_imports(self.interface.butler, group="1", detector=56,
                             expected_shards=expected_shards, expected_date="20150218T000000Z")
 
     def test_prep_butler_olddate(self):
@@ -305,9 +315,9 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         expected_shards = {157394, 157401, 157405}
         with self.assertRaises((AssertionError, lsst.daf.butler.registry.MissingCollectionError)):
             # 20150218T000000Z run should not be imported
-            self._check_imports(self.interface.butler, detector=56,
+            self._check_imports(self.interface.butler, group="1", detector=56,
                                 expected_shards=expected_shards, expected_date="20150218T000000Z")
-        self._check_imports(self.interface.butler, detector=56,
+        self._check_imports(self.interface.butler, group="1", detector=56,
                             expected_shards=expected_shards, expected_date="20150313T000000Z")
 
     # TODO: prep_butler doesn't know what kinds of calibs to expect, so can't
@@ -345,7 +355,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
 
         second_interface.prep_butler()
         expected_shards = {157394, 157401, 157405}
-        self._check_imports(second_interface.butler, detector=56,
+        self._check_imports(second_interface.butler, group="2", detector=56,
                             expected_shards=expected_shards, expected_date="20150218T000000Z")
 
         # Third visit with different detector and coordinates.
@@ -362,7 +372,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                                               prefix="file://")
         third_interface.prep_butler()
         expected_shards.update({157393, 157395})
-        self._check_imports(third_interface.butler, detector=5,
+        self._check_imports(third_interface.butler, group="3", detector=5,
                             expected_shards=expected_shards, expected_date="20150218T000000Z")
 
     def test_ingest_image(self):


### PR DESCRIPTION
This PR writes a `RegionTimeInfo` dataset directly to the preload run so that it can be used by preprocessing tasks.