### PR TITLE
DM-44189: Remove ccdVisitId from Prompt Processing

### DIFF
--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -1082,14 +1082,11 @@ class MiddlewareInterface:
                 state_changed = True  # better safe than sorry
                 try:
                     data_ids = set(self.butler.registry.queryDataIds(
-                        ["instrument", "visit", "detector"], where=where).expanded())
+                        ["instrument", "visit", "detector"], where=where))
                     if len(data_ids) == 1:
                         data_id = list(data_ids)[0]
-                        packer = self.instrument.make_default_dimension_packer(data_id, is_exposure=False)
-                        ccd_visit_id = packer.pack(data_id, returnMaxBits=False)
                         apdb = lsst.dax.apdb.Apdb.from_uri(self._apdb_config)
-                        # HACK: this method only works for ApdbSql; not needed after DM-41671
-                        if not apdb.containsCcdVisit(ccd_visit_id):
+                        if not apdb.containsVisitDetector(data_id["visit"], self.visit.detector):
                             state_changed = False
                     else:
                         # Don't know how this could happen, so won't try to handle it gracefully.

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -574,7 +574,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                 "activator.middleware_interface.SeparablePipelineExecutor.pre_execute_qgraph"), \
              unittest.mock.patch("activator.middleware_interface.SeparablePipelineExecutor.run_pipeline") \
                 as mock_run, \
-             unittest.mock.patch("lsst.dax.apdb.ApdbSql.containsCcdVisit") as mock_query:
+             unittest.mock.patch("lsst.dax.apdb.ApdbSql.containsVisitDetector") as mock_query:
             mock_run.side_effect = RuntimeError("The pipeline doesn't like you.")
             mock_query.return_value = False
             with self.assertRaises(RuntimeError):
@@ -589,7 +589,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                 "activator.middleware_interface.SeparablePipelineExecutor.pre_execute_qgraph"), \
              unittest.mock.patch("activator.middleware_interface.SeparablePipelineExecutor.run_pipeline") \
                 as mock_run, \
-             unittest.mock.patch("lsst.dax.apdb.ApdbSql.containsCcdVisit") as mock_query:
+             unittest.mock.patch("lsst.dax.apdb.ApdbSql.containsVisitDetector") as mock_query:
             mock_run.side_effect = RuntimeError("The pipeline doesn't like you.")
             mock_query.return_value = True
             with self.assertRaises(NonRetriableError):
@@ -604,7 +604,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                 "activator.middleware_interface.SeparablePipelineExecutor.pre_execute_qgraph"), \
              unittest.mock.patch("activator.middleware_interface.SeparablePipelineExecutor.run_pipeline") \
                 as mock_run, \
-             unittest.mock.patch("lsst.dax.apdb.ApdbSql.containsCcdVisit") as mock_query:
+             unittest.mock.patch("lsst.dax.apdb.ApdbSql.containsVisitDetector") as mock_query:
             mock_run.side_effect = RuntimeError("The pipeline doesn't like you.")
             mock_query.side_effect = psycopg2.OperationalError("Database? What database?")
             with self.assertRaises(NonRetriableError):


### PR DESCRIPTION
This PR retries the core commit from #160, which was rolled back on #162. It appears the errors were caused by external factors rather than the code itself, so no changes are needed.