### PR TITLE
DM-42925: Add support for preprocessing pipeline to Prompt Processing

### DIFF
--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -70,7 +70,7 @@ kafka_group_id = str(uuid.uuid4())
 # The topic on which to listen to updates to image_bucket
 bucket_topic = os.environ.get("BUCKET_TOPIC", "rubin-prompt-processing")
 # The pipelines to execute and the conditions in which to choose them.
-pipelines = PipelinesConfig(os.environ["PIPELINES_CONFIG"])
+main_pipelines = PipelinesConfig(os.environ["MAIN_PIPELINES_CONFIG"])
 
 setup_usdf_logger(
     labels={"instrument": instrument_name},
@@ -269,7 +269,7 @@ def next_visit_handler() -> Tuple[str, int]:
             return f"Bad Request: {msg}", 400
         assert expected_visit.instrument == instrument_name, \
             f"Expected {instrument_name}, received {expected_visit.instrument}."
-        if not pipelines.get_pipeline_files(expected_visit):
+        if not main_pipelines.get_pipeline_files(expected_visit):
             _log.info(f"No pipeline configured for {expected_visit}, skipping.")
             return "No pipeline configured for the received visit.", 422
 
@@ -285,7 +285,7 @@ def next_visit_handler() -> Tuple[str, int]:
             mwi = MiddlewareInterface(central_butler,
                                       image_bucket,
                                       expected_visit,
-                                      pipelines,
+                                      main_pipelines,
                                       skymap,
                                       local_repo.name)
             # Copy calibrations for this detector/visit

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -69,7 +69,9 @@ kafka_cluster = os.environ["KAFKA_CLUSTER"]
 kafka_group_id = str(uuid.uuid4())
 # The topic on which to listen to updates to image_bucket
 bucket_topic = os.environ.get("BUCKET_TOPIC", "rubin-prompt-processing")
-# The pipelines to execute and the conditions in which to choose them.
+# The preprocessing pipelines to execute and the conditions in which to choose them.
+pre_pipelines = PipelinesConfig(os.environ["PREPROCESSING_PIPELINES_CONFIG"])
+# The main pipelines to execute and the conditions in which to choose them.
 main_pipelines = PipelinesConfig(os.environ["MAIN_PIPELINES_CONFIG"])
 
 setup_usdf_logger(
@@ -285,6 +287,7 @@ def next_visit_handler() -> Tuple[str, int]:
             mwi = MiddlewareInterface(central_butler,
                                       image_bucket,
                                       expected_visit,
+                                      pre_pipelines,
                                       main_pipelines,
                                       skymap,
                                       local_repo.name)

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -1130,7 +1130,7 @@ class MiddlewareInterface:
             # *Diff_diaSrcTable, etc. have not been registered.
             # TODO: after DM-38041, move pre-execution to one-time repo setup.
             executor.pre_execute_qgraph(qgraph, register_dataset_types=True, save_init_outputs=True)
-            _log.info(f"Running '{pipeline._pipelineIR.description}' on {where}")
+            _log.info(f"Running '{pipeline_file}' on {where}")
             try:
                 with lsst.utils.timer.time_this(_log, msg="executor.run_pipeline", level=logging.DEBUG):
                     executor.run_pipeline(

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -938,7 +938,7 @@ class MiddlewareInterface:
                 self._get_output_run(pipeline_file, self._day_obs),
                 CollectionType.RUN)
 
-    def _get_pipeline_files(self) -> str:
+    def _get_pipeline_files(self) -> collections.abc.Sequence[str]:
         """Identify the pipelines to be run, based on the configured instrument
         and visit.
 

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -996,11 +996,9 @@ class MiddlewareInterface:
         """
         pipeline = lsst.pipe.base.Pipeline.fromFile(pipeline_file)
 
-        try:
-            pipeline.addConfigOverride("parameters", "apdb_config", self._apdb_config)
-        except LookupError:
-            _log.warning(f"{pipeline_file} does not have an `apdb_config` parameter; "
-                         "assuming no APDB support is needed.")
+        # Config overrides are not validated until graph generation.
+        pipeline.addConfigOverride("parameters", "apdb_config", self._apdb_config)
+
         return pipeline
 
     def _download(self, remote):

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -455,10 +455,14 @@ class MiddlewareInterface:
                 with time_this_to_bundle(bundle, action_id, "prep_butlerTransferTime"):
                     self._transfer_data(all_datasets, calib_datasets)
 
+                with time_this_to_bundle(bundle, action_id, "prep_butlerPreprocessTime"):
+                    self._run_preprocessing()
+
         # IMPORTANT: do not remove or rename entries in this list. New entries can be added as needed.
         enforce_schema(bundle, {action_id: ["prep_butlerTotalTime",
                                             "prep_butlerSearchTime",
                                             "prep_butlerTransferTime",
+                                            "prep_butlerPreprocessTime",
                                             ]})
         self.butler.registry.registerDatasetType(DatasetType(
             "promptPreload_metrics",

--- a/python/dummyTask.py
+++ b/python/dummyTask.py
@@ -1,0 +1,49 @@
+# This file is part of prompt_processing.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+__all__ = ["DummyTask"]
+
+
+import lsst.pipe.base as pipe_base
+
+
+class DummyConnections(pipe_base.PipelineTaskConnections,
+                       dimensions={"instrument", "group", "detector"},
+                       ):
+    # Emulate actual input for PreloadApdbTask
+    input = pipe_base.connectionTypes.Input(
+        doc="The (possibly predicted) region and time associated with this group.",
+        name="regionTimeInfo",
+        storageClass="RegionTimeInfo",
+        dimensions={"instrument", "group", "detector"},
+    )
+
+
+class DummyConfig(pipe_base.PipelineTaskConfig, pipelineConnections=DummyConnections):
+    pass
+
+
+# TODO: This class is a test placeholder until real tasks can be implemented.
+# Remove this file after DM-31833 or DM-42576.
+class DummyTask(pipe_base.PipelineTask):
+    _DefaultName = "dummy"
+    ConfigClass = DummyConfig

--- a/tests/data/MinPrep.yaml
+++ b/tests/data/MinPrep.yaml
@@ -1,0 +1,4 @@
+description: A preprocessing pipeline for testing. Must generate quantum graph, but no tasks actually run.
+tasks:
+  # TODO: replace after DM-31833 or DM-42576
+  dummy: dummyTask.DummyTask

--- a/tests/data/NoPrep.yaml
+++ b/tests/data/NoPrep.yaml
@@ -1,0 +1,4 @@
+description: A preprocessing pipeline for testing. Must generate quantum graph, but no tasks actually run.
+tasks:
+  # TODO: replace after DM-31833 or DM-42576
+  dummy: dummyTask.DummyTask

--- a/tests/data/Preprocess.yaml
+++ b/tests/data/Preprocess.yaml
@@ -1,0 +1,4 @@
+description: A preprocessing pipeline for testing. Must generate quantum graph, but no tasks actually run.
+tasks:
+  # TODO: replace after DM-31833 or DM-42576
+  dummy: dummyTask.DummyTask

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -477,8 +477,9 @@ class MiddlewareInterfaceTest(unittest.TestCase):
             The description of the pipeline that should be run, given
             ``pipe_files`` and ``graphs``.
         """
-        with unittest.mock.patch("activator.middleware_interface.MiddlewareInterface._get_pipeline_files",
-                                 return_value=pipe_files), \
+        with unittest.mock.patch(
+            "activator.middleware_interface.MiddlewareInterface._get_main_pipeline_files",
+            return_value=pipe_files), \
                 unittest.mock.patch(
                     "activator.middleware_interface.SeparablePipelineExecutor.make_quantum_graph",
                     side_effect=graphs), \

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -471,11 +471,13 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         # Check that we configured the right pipeline.
         self.assertIn(os.path.join(self.data_dir, 'ApPipe.yaml'), "\n".join(logs.output))
 
-    def _check_run_pipeline_fallback(self, pipe_files, graphs, final_label):
+    def _check_run_pipeline_fallback(self, callable, pipe_files, graphs, final_label):
         """Generic test for different fallback scenarios.
 
         Parameters
         ----------
+        callable : callable [[]]
+            A nullary callable that runs the target pipeline(s).
         pipe_files : sequence [`str`]
             The list of pipeline files configured for a visit.
         graphs : sequence [`collections.abc.Sized`]
@@ -496,7 +498,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                 unittest.mock.patch("activator.middleware_interface.SeparablePipelineExecutor.run_pipeline") \
                 as mock_run, \
                 self.assertLogs(self.logger_name, level="INFO") as logs:
-            self.interface.run_pipeline({1})
+            callable()
         mock_run.assert_called_once()
         # Check that we configured the right pipeline.
         self.assertIn(final_label, "\n".join(logs.output))
@@ -508,7 +510,8 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         expected = "SingleFrame.yaml"
 
         self._prepare_run_pipeline()
-        self._check_run_pipeline_fallback(pipe_list, graph_list, expected)
+        self._check_run_pipeline_fallback(lambda: self.interface.run_pipeline({1}),
+                                          pipe_list, graph_list, expected)
 
     def test_run_pipeline_fallback_1failof2_inverse(self):
         pipe_list = [os.path.join(self.data_dir, 'ApPipe.yaml'),
@@ -517,7 +520,8 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         expected = "ApPipe.yaml"
 
         self._prepare_run_pipeline()
-        self._check_run_pipeline_fallback(pipe_list, graph_list, expected)
+        self._check_run_pipeline_fallback(lambda: self.interface.run_pipeline({1}),
+                                          pipe_list, graph_list, expected)
 
     def test_run_pipeline_fallback_2failof2(self):
         pipe_list = [os.path.join(self.data_dir, 'ApPipe.yaml'),
@@ -527,7 +531,8 @@ class MiddlewareInterfaceTest(unittest.TestCase):
 
         self._prepare_run_pipeline()
         with self.assertRaises(RuntimeError):
-            self._check_run_pipeline_fallback(pipe_list, graph_list, expected)
+            self._check_run_pipeline_fallback(lambda: self.interface.run_pipeline({1}),
+                                              pipe_list, graph_list, expected)
 
     def test_run_pipeline_fallback_0failof3(self):
         pipe_list = [os.path.join(self.data_dir, 'ApPipe.yaml'),
@@ -537,7 +542,8 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         expected = "ApPipe.yaml"
 
         self._prepare_run_pipeline()
-        self._check_run_pipeline_fallback(pipe_list, graph_list, expected)
+        self._check_run_pipeline_fallback(lambda: self.interface.run_pipeline({1}),
+                                          pipe_list, graph_list, expected)
 
     def test_run_pipeline_fallback_1failof3(self):
         pipe_list = [os.path.join(self.data_dir, 'ApPipe.yaml'),
@@ -547,7 +553,8 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         expected = "SingleFrame.yaml"
 
         self._prepare_run_pipeline()
-        self._check_run_pipeline_fallback(pipe_list, graph_list, expected)
+        self._check_run_pipeline_fallback(lambda: self.interface.run_pipeline({1}),
+                                          pipe_list, graph_list, expected)
 
     def test_run_pipeline_fallback_2failof3(self):
         pipe_list = [os.path.join(self.data_dir, 'ApPipe.yaml'),
@@ -557,7 +564,8 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         expected = "ISR.yaml"
 
         self._prepare_run_pipeline()
-        self._check_run_pipeline_fallback(pipe_list, graph_list, expected)
+        self._check_run_pipeline_fallback(lambda: self.interface.run_pipeline({1}),
+                                          pipe_list, graph_list, expected)
 
     def test_run_pipeline_fallback_2failof3_inverse(self):
         pipe_list = [os.path.join(self.data_dir, 'ApPipe.yaml'),
@@ -567,7 +575,8 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         expected = "SingleFrame.yaml"
 
         self._prepare_run_pipeline()
-        self._check_run_pipeline_fallback(pipe_list, graph_list, expected)
+        self._check_run_pipeline_fallback(lambda: self.interface.run_pipeline({1}),
+                                          pipe_list, graph_list, expected)
 
     def test_run_pipeline_bad_visits(self):
         """Test that running a pipeline that results in bad visit definition

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -461,8 +461,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         self.assertEqual(mock_preexec.call_args.kwargs["register_dataset_types"], True)
         mock_run.assert_called_once()
         # Check that we configured the right pipeline.
-        self.assertIn("End to end Alert Production pipeline specialized for HiTS-2015",
-                      "\n".join(logs.output))
+        self.assertIn(os.path.join(self.data_dir, 'ApPipe.yaml'), "\n".join(logs.output))
 
     def _check_run_pipeline_fallback(self, pipe_files, graphs, final_label):
         """Generic test for different fallback scenarios.
@@ -497,7 +496,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         pipe_list = [os.path.join(self.data_dir, 'ApPipe.yaml'),
                      os.path.join(self.data_dir, 'SingleFrame.yaml')]
         graph_list = [[], ["node1", "node2"]]
-        expected = "Test pipeline consisting only of single-frame steps."
+        expected = "SingleFrame.yaml"
 
         self._prepare_run_pipeline()
         self._check_run_pipeline_fallback(pipe_list, graph_list, expected)
@@ -506,7 +505,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         pipe_list = [os.path.join(self.data_dir, 'ApPipe.yaml'),
                      os.path.join(self.data_dir, 'SingleFrame.yaml')]
         graph_list = [["node1", "node2"], []]
-        expected = "End to end Alert Production pipeline specialized for HiTS-2015"
+        expected = "ApPipe.yaml"
 
         self._prepare_run_pipeline()
         self._check_run_pipeline_fallback(pipe_list, graph_list, expected)
@@ -526,7 +525,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                      os.path.join(self.data_dir, 'SingleFrame.yaml'),
                      os.path.join(self.data_dir, 'ISR.yaml')]
         graph_list = [["node1", "node2"], ["node3", "node4"], ["node5"]]
-        expected = "End to end Alert Production pipeline specialized for HiTS-2015"
+        expected = "ApPipe.yaml"
 
         self._prepare_run_pipeline()
         self._check_run_pipeline_fallback(pipe_list, graph_list, expected)
@@ -536,7 +535,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                      os.path.join(self.data_dir, 'SingleFrame.yaml'),
                      os.path.join(self.data_dir, 'ISR.yaml')]
         graph_list = [[], ["node3", "node4"], ["node5"]]
-        expected = "Test pipeline consisting only of single-frame steps."
+        expected = "SingleFrame.yaml"
 
         self._prepare_run_pipeline()
         self._check_run_pipeline_fallback(pipe_list, graph_list, expected)
@@ -546,7 +545,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                      os.path.join(self.data_dir, 'SingleFrame.yaml'),
                      os.path.join(self.data_dir, 'ISR.yaml')]
         graph_list = [[], [], ["node5"]]
-        expected = "Test pipeline consisting only of ISR."
+        expected = "ISR.yaml"
 
         self._prepare_run_pipeline()
         self._check_run_pipeline_fallback(pipe_list, graph_list, expected)
@@ -556,7 +555,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                      os.path.join(self.data_dir, 'SingleFrame.yaml'),
                      os.path.join(self.data_dir, 'ISR.yaml')]
         graph_list = [[], ["node3", "node4"], []]
-        expected = "Test pipeline consisting only of single-frame steps."
+        expected = "SingleFrame.yaml"
 
         self._prepare_run_pipeline()
         self._check_run_pipeline_fallback(pipe_list, graph_list, expected)


### PR DESCRIPTION
This PR adds supporting code that allows a pipeline(s) to be run during `prep_butler`. Without any tasks that can be run on a pre-ingestion repo, however, testing is difficult; many of the changes to the unit tests are workarounds to prevent actual task execution in `prep_butler`.