### PR TITLE
DM-40193: Disk space leak in prompt processing

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,2 +1,2 @@
-Copyright 2022 The Board of Trustees of the Leland Stanford Junior University, through SLAC National Accelerator Laboratory
-Copyright 2022 University of Washington
+Copyright 2022-2024 The Board of Trustees of the Leland Stanford Junior University, through SLAC National Accelerator Laboratory
+Copyright 2022-2024 University of Washington

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -39,7 +39,7 @@ from werkzeug.exceptions import ServiceUnavailable
 from .config import PipelinesConfig
 from .exception import NonRetriableError, RetriableError
 from .logger import setup_usdf_logger
-from .middleware_interface import get_central_butler, make_local_repo, MiddlewareInterface
+from .middleware_interface import get_central_butler, make_local_repo, make_local_cache, MiddlewareInterface
 from .raw import (
     get_prefix_from_snap,
     is_path_consistent,
@@ -96,6 +96,7 @@ try:
     central_butler = get_central_butler(calib_repo, instrument_name)
     # local_repo is a temporary directory with the same lifetime as this process.
     local_repo = make_local_repo(local_repos, central_butler, instrument_name)
+    local_cache = make_local_cache()
 except Exception as e:
     _log.critical("Failed to start worker; aborting.")
     _log.exception(e)
@@ -290,7 +291,8 @@ def next_visit_handler() -> Tuple[str, int]:
                                       pre_pipelines,
                                       main_pipelines,
                                       skymap,
-                                      local_repo.name)
+                                      local_repo.name,
+                                      local_cache)
             # Copy calibrations for this detector/visit
             mwi.prep_butler()
 

--- a/python/activator/caching.py
+++ b/python/activator/caching.py
@@ -1,0 +1,256 @@
+# This file is part of prompt_processing.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+__all__ = ["DatasetCache"]
+
+
+import collections
+from collections.abc import Collection, Iterable, Iterator, Mapping, Set
+import copy
+import functools
+import itertools
+import logging
+from typing import Callable
+import warnings
+
+import lsst.daf.butler as daf_butler
+
+from .evictingSet import EvictingSet, RandomReplacementSet
+
+
+_log = logging.getLogger("lsst." + __name__)
+_log.setLevel(logging.DEBUG)
+# See https://developer.lsst.io/stack/logging.html#logger-trace-verbosity
+_log_trace = logging.getLogger("TRACE1.lsst." + __name__)
+_log_trace.setLevel(logging.CRITICAL)  # Turn off by default.
+
+
+def _check_component(dataset_type: daf_butler.DatasetType):
+    """Test whether an operation tries to insert a component dataset.
+
+     Parameters
+    ----------
+    dataset_type : `lsst.daf.butler.DatasetType`
+        The type to test.
+
+    Raises
+    ------
+    ValueError
+        Raised if the type is a component.
+    """
+    if dataset_type.isComponent():
+        raise ValueError(f"Cannot store a dataset of type {dataset_type}, "
+                         f"store a {dataset_type.makeCompositeDatasetType()} instead.")
+
+
+def _get_parent_ref(dataset_ref: daf_butler.DatasetRef) -> daf_butler.DatasetRef:
+    """Return a reference to a dataset's top-level dataset.
+
+     Parameters
+    ----------
+    dataset_ref : `lsst.daf.butler.DatasetRef`
+        The reference to promote.
+
+    Returns
+    -------
+    parent_ref : `lsst.daf.butler.DatasetRef`
+        The top-level reference associated with ``dataset_ref``. May be the
+        same object if ``dataset_ref`` is not a component.
+    """
+    if dataset_ref.isComponent():
+        return _get_parent_ref(dataset_ref.makeCompositeRef())
+    else:
+        return dataset_ref
+
+
+class DatasetCache(collections.abc.Collection[daf_butler.DatasetRef]):
+    """A container for storing a limited number of datasets.
+
+    Attempts to add datasets beyond the configured limits remove objects from
+    the cache.
+
+    This object can only store references to top-level datasets, not
+    components.
+
+    Parameters
+    ----------
+    default_cache_size : `int`
+        The number of datasets per type to cache, unless overridden by
+        ``cache_sizes``.
+    cache_sizes : mapping [`str` or `~lsst.daf.butler.DatasetType`, `int`], optional
+        A map from dataset types to the number of datasets of that type to
+        cache. Any types not in the map are handled according to
+        ``default_cache_size``.
+    cache_factory : callable [(`int`), `activator.evictingSet.EvictingSet`], optional
+        A callable for creating new caches for each dataset type. It must take
+        the desired cache size and return an empty set. If not provided, a
+        default cache implementation is used.
+    """
+    def __init__(self,
+                 default_cache_size: int,
+                 cache_sizes: Mapping[str | daf_butler.DatasetType, int] | None = None,
+                 cache_factory: Callable[[int], EvictingSet] | None = None,
+                 ):
+        super().__init__()
+
+        if default_cache_size < 0:
+            raise ValueError(f"Cannot create negative-sized cache, got {default_cache_size}.")
+
+        if cache_sizes is None:
+            cache_sizes = {}
+        if cache_factory is None:
+            cache_factory = RandomReplacementSet
+
+        # Index by str
+        self._caches = collections.defaultdict(
+            functools.partial(cache_factory, default_cache_size),
+            {t if isinstance(t, str) else t.name: cache_factory(n)
+             for t, n in cache_sizes.items()}
+        )
+        bad_types = {name for name in self._caches.keys() if "." in name}
+        if bad_types:
+            raise ValueError(f"Cannot cache component datasets: {bad_types}")
+
+    def __contains__(self, item: daf_butler.DatasetRef):
+        # Don't index the defaultdict with a component.
+        if item.isComponent():
+            return False
+        return item in self._caches[item.datasetType.name]
+
+    def __iter__(self) -> Iterator[daf_butler.DatasetRef]:
+        return itertools.chain.from_iterable(self._caches.values())
+
+    def __len__(self):
+        total = 0
+        for cache in self._caches.values():
+            total += len(cache)
+        return total
+
+    def _merge_into_cache(self, inputs: Mapping[str, Set[daf_butler.DatasetRef]]) \
+            -> [Set[daf_butler.DatasetRef], Set[daf_butler.DatasetRef], Mapping[str, EvictingSet]]:
+        """Compute a bulk update of caches for multiple dataset types.
+
+        This method finds a combination of insertions and evictions that
+        satisfies the configured caching strategy. It does not update any
+        state itself.
+
+        If ``inputs`` cannot all fit in the cache, this method emits a warning.
+
+        Parameters
+        ----------
+        inputs : mapping [`str`, set [`lsst.daf.butler.DatasetRef`]]
+            The dataset refs to insert, after any trimming for invalid inputs.
+            The keys are the dataset type names.
+
+        Returns
+        -------
+        to_evict : set [`lsst.daf.butler.DatasetRef`]
+            The datasets to remove from the Butler repo and the cache.
+        to_add : set [`lsst.daf.butler.DatasetRef`]
+            The datasets to add to the repo and the cache. May be a subset of
+            the refs in ``inputs``.
+        caches : mapping [`str`,  `activator.evictingSet.EvictingSet`]
+            The new cache states after removing ``to_evict`` and inserting
+            ``to_add``. The mapping need not include caches that don't need to
+            be updated.
+        """
+        to_evict = set()
+        to_add = set()
+        excess = set()
+        caches = {}
+        for name in inputs.keys():
+            caches[name] = copy.copy(self._caches[name])
+            caches[name] |= inputs[name]
+            assert isinstance(caches[name], EvictingSet)  # guard against Python operand-swapping
+            to_evict.update(self._caches[name] - caches[name])
+            to_add.update(caches[name] - self._caches[name])
+            excess.update(inputs[name] - caches[name])
+        if excess:
+            warnings.warn(f"Cannot store all inputs in cache; dropping {excess}.", RuntimeWarning)
+        return to_evict, to_add, caches
+
+    def update(self, others: Iterable[daf_butler.DatasetRef]) -> Collection[daf_butler.DatasetRef]:
+        """Add multiple datasets to the cache.
+
+        Datasets may be evicted from the cache, but the datasets in ``others``
+        will be dropped only if they cannot all fit.
+
+        Parameters
+        ----------
+        others : iterable [`lsst.daf.butler.DatasetRef`]
+            The datasets to attempt to add to the cache.
+
+        Returns
+        -------
+        evicted : collection [`lsst.daf.butler.DatasetRef`]
+            The datasets evicted from cache. Does not include any members of
+            ``others`` that could not be added.
+
+        Notes
+        -----
+        The cache is not updated in the event of an exception.
+        """
+        grouped_refs = collections.defaultdict(set)
+        for ref in others:
+            _check_component(ref.datasetType)
+            grouped_refs[ref.datasetType.name].add(ref)
+
+        # Copy-and-swap caches for atomic behavior.
+        to_evict, _, new_caches = self._merge_into_cache(grouped_refs)
+
+        self._caches.update(new_caches)
+        if to_evict:
+            _log.debug("Evicting datasets: %s", to_evict)
+        return to_evict
+
+    def access(self, others: Iterable[daf_butler.DatasetRef]):
+        """Mark use of multiple datasets.
+
+        Usage statistics may be used by the cache algorithm to prioritize
+        evictions.
+
+        Parameters
+        ----------
+        others : iterable [`lsst.daf.butler.DatasetRef`]
+            The datasets to mark as used.
+
+        Raises
+        ------
+        LookupError
+            Raised if one or more of the datasets are not in the cache.
+
+        Notes
+        -----
+        Usage statistics are not updated in the event of an exception.
+        """
+        grouped_refs = collections.defaultdict(set)
+        for ref in others:
+            parent_ref = _get_parent_ref(ref)
+            grouped_refs[parent_ref.datasetType.name].add(parent_ref)
+
+        # Copy-and-swap caches for atomic behavior
+        _temp = {}
+        for name, refs in grouped_refs.items():
+            _temp[name] = copy.copy(self._caches[name])
+            for ref in refs:
+                _temp[name].get(ref)
+        self._caches.update(_temp)

--- a/python/activator/evictingSet.py
+++ b/python/activator/evictingSet.py
@@ -1,0 +1,160 @@
+# This file is part of prompt_processing.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+__all__ = ["EvictingSet"]
+
+
+import abc
+import collections.abc
+from typing import Any, Self
+
+
+# TODO: implementing the full MutableSet API is overkill, and both the API's
+# reliance on updating operators and the default implementations in MutableSet
+# are potentially dangerous. Reimplement as a Collection that does not claim to
+# be a set.
+class EvictingSet(collections.abc.MutableSet):
+    """An interface for sets that store a maximum number of elements, removing
+    excess elements as needed.
+
+    All operations are guaranteed to be atomic; in particular, a failed
+    operation never evicts. The actual eviction policy is up to
+    the implementation.
+    """
+    @property
+    @abc.abstractmethod
+    def max_size(self) -> int:
+        """The maximum set size (`int`, read-only).
+
+        Any insertions above this size trigger eviction.
+        """
+
+    def __and__(self, other: collections.abc.Set) -> Self:
+        """Return a new set with elements common to the set and ``other``.
+
+        The returned set is of the same type as the first operand, and has the
+        same `max_size`.
+        """
+        return super().__and__(other)
+
+    def __or__(self, other: collections.abc.Set) -> Self:
+        """Return a new set with elements from the set and ``other``.
+
+        The returned set is of the same type as the first operand, and has the
+        same `max_size`. If the length of the result would exceed `max_size`,
+        evictions are made as if this set had been copied, then updated with |=.
+        """
+        return super().__or__(other)
+
+    def __sub__(self, other: collections.abc.Set) -> Self:
+        """Return a new set with elements in the set that are not in the others.
+
+        The returned set is of the same type as the first operand, and has the
+        same `max_size`.
+        """
+        return super().__sub__(other)
+
+    def __xor__(self, other: collections.abc.Set) -> Self:
+        """Return a new set with elements in either the set or ``other`` but
+        not both.
+
+        The returned set is of the same type as the first operand, and has the
+        same `max_size`. If the length of the result would exceed `max_size`,
+        evictions are made as if this set had been copied, then updated with ^=.
+        """
+        return super().__xor__(other)
+
+    @abc.abstractmethod
+    def add(self, elem: Any) -> Any | None:
+        """Add element ``elem`` to the set.
+
+        Parameters
+        ----------
+        elem
+            The element to add to the set.
+
+        Returns
+        -------
+        evicted : optional
+            The element removed to make way for ``elem``, or `None` if no
+            eviction was done.
+        """
+
+    @abc.abstractmethod
+    def get(self, elem: Any) -> Any:
+        """\"Read\" an element from the set.
+
+        This method exists to support eviction algorithms that depend on
+        elements' usage patterns. Clients can use it to prioritize elements
+        for retention.
+
+        Parameters
+        ----------
+        elem
+            The element to "retrieve" from the set.
+
+        Returns
+        -------
+        elem
+            The element, which may or may not be the same object as the
+            input argument.
+
+        Raises
+        ------
+        KeyError
+            Raised if the set does not contain ``elem``.
+        """
+
+    def __ior__(self, other: collections.abc.Iterable) -> Self:
+        """Update the set, adding elements from all others.
+
+        If the length of the result would exceed `max_size`, evictions are made
+        as if each object returned from ``other`` had been inserted, one by one,
+        by `add`.
+
+        Parameters
+        ----------
+        other : iterable
+            The iterable from which to add elements.
+        """
+        return super().__ior__(other)
+
+    def __ixor__(self, other: collections.abc.Iterable) -> Self:
+        """Update the set, keeping only elements found in either set, but not
+        in both.
+
+        If the length of the result would exceed `max_size`, evictions are made
+        as if all ineligible members of this set had been removed first, then
+        each eligible object returned from ``other`` had been inserted, one by
+        one, by `add`.
+
+        Parameters
+        ----------
+        other : iterable
+            The iterable from which to update elements.
+        """
+        return super().__ixor__(other)
+
+    # set also implements issubset, issuperset, union, intersection, difference,
+    # symmetric_difference, copy, update, intersection_update,
+    # difference_update, and symmetric_difference_update, but MutableSet does
+    # not require these.

--- a/python/activator/evictingSet.py
+++ b/python/activator/evictingSet.py
@@ -39,6 +39,14 @@ class EvictingSet(collections.abc.MutableSet):
     All operations are guaranteed to be atomic; in particular, a failed
     operation never evicts. The actual eviction policy is up to
     the implementation.
+
+    Notes
+    -----
+    The definitions of binary operators guarantee that the values from the
+    right-hand-side will not be evicted unless necessary. This convention allows
+    the creating and in-place operations to behave consistently (e.g.,
+    ``a |= b`` is equivalent to ``a = a | b``). However, this means that binary
+    operations are not symmetric.
     """
     @property
     @abc.abstractmethod
@@ -128,8 +136,11 @@ class EvictingSet(collections.abc.MutableSet):
         """Update the set, adding elements from all others.
 
         If the length of the result would exceed `max_size`, evictions are made
-        as if each object returned from ``other`` had been inserted, one by one,
-        by `add`.
+        as if each object returned from ``other`` had been inserted
+        simultaneously. The new objects are only evicted if the length of
+        ``other`` also exceeds `max_size`. This guarantee gives behavior
+        inconsistent with iterating and calling `add`, but gives sensible
+        results for eviction strategies that penalize recently-added objects.
 
         Parameters
         ----------
@@ -144,8 +155,11 @@ class EvictingSet(collections.abc.MutableSet):
 
         If the length of the result would exceed `max_size`, evictions are made
         as if all ineligible members of this set had been removed first, then
-        each eligible object returned from ``other`` had been inserted, one by
-        one, by `add`.
+        each eligible object returned from ``other`` had been inserted
+        simultaneously. The new objects are only evicted if their number
+        also exceeds `max_size`. This guarantee gives behavior
+        inconsistent with iterating and calling `add`, but gives sensible
+        results for eviction strategies that penalize recently-added objects.
 
         Parameters
         ----------

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -72,8 +72,6 @@ template_factor = int(os.environ.get("PATCHES_PER_IMAGE", 4))
 # VALIDITY-HACK: local-only calib collections break if calibs are not requested
 # in chronological order. Turn off for large development runs.
 cache_calibs = bool(int(os.environ.get("DEBUG_CACHE_CALIBS", '1')))
-# TODO: workaround for DM-40193
-cache_anything = bool(int(os.environ.get("DEBUG_CACHE_INPUTS", '1')))
 
 
 def get_central_butler(central_repo: str, instrument_class: str):
@@ -1628,10 +1626,6 @@ class MiddlewareInterface:
             if excess_datasets:
                 _log_trace.debug("Clearing out %s.", excess_datasets)
                 self.butler.pruneDatasets(excess_datasets, disassociate=True, unstore=True, purge=True)
-            # TODO: workaround for DM-40193
-            if not cache_anything:
-                self.butler.pruneDatasets(self.butler.registry.queryDatasets(...),
-                                          disassociate=True, unstore=True, purge=True)
 
 
 class _MissingDatasetError(RuntimeError):

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -1,0 +1,219 @@
+# This file is part of prompt_processing.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+
+from lsst.daf.butler import Butler, DataCoordinate, DatasetRef, DatasetType, DimensionUniverse
+import lsst.daf.butler.tests as butler_tests
+
+from activator.caching import DatasetCache
+from activator.evictingSet import RandomReplacementSet
+
+
+class DatasetCacheTest(unittest.TestCase):
+    def _cache_factory(self, size):
+        # Variable seed gives better coverage of edge cases.
+        return RandomReplacementSet(size, seed=abs(hash(self.id())))
+
+    @classmethod
+    def _make_test_repo(cls, location):
+        """Create and initialize a test repo.
+
+        Parameters
+        ----------
+        location : `str`
+            The directory in which to create a repo.
+
+        Returns
+        -------
+        butler : `lsst.daf.butler.Butler`
+            A Butler pointing to the newly-created repo.
+        """
+        # Don't use butler_tests.makeTestRepo; in-memory repos can't handle export or transfer_from
+        butler = Butler(Butler.makeRepo(location), run="testRun")
+
+        butler_tests.addDataIdValue(butler, "instrument", "NotACam")
+        butler_tests.addDataIdValue(butler, "physical_filter", "k2024", band="k")
+        butler_tests.addDataIdValue(butler, "exposure", 42)
+        butler_tests.addDataIdValue(butler, "detector", 0)
+        butler_tests.addDataIdValue(butler, "detector", 1)
+        butler_tests.addDataIdValue(butler, "detector", 2)
+
+        butler_tests.addDatasetType(butler, "int1", {"instrument"}, "int")
+        butler_tests.addDatasetType(butler, "int2", {"instrument", "exposure", "detector"}, "int")
+        butler_tests.addDatasetType(butler, "int3", {"instrument", "exposure", "detector"}, "int")
+        butler_tests.addDatasetType(butler, "exp", {"instrument", "exposure", "detector"}, "Exposure")
+
+        return butler
+
+    def setUp(self):
+        universe = DimensionUniverse()
+
+        self.type1 = DatasetType("int1", {"instrument"}, "int", universe=universe)
+        self.type2 = DatasetType("int2", {"instrument", "exposure", "detector"}, "int", universe=universe)
+        self.type3 = DatasetType("int3", {"instrument", "exposure", "detector"}, "int", universe=universe)
+        self.typeE = DatasetType("exp", {"instrument", "exposure", "detector"}, "Exposure", universe=universe)
+
+        self.ref1 = DatasetRef(self.type1,
+                               DataCoordinate.standardize({"instrument": "NotACam"}, universe=universe),
+                               run="testRun")
+        self.ref20 = DatasetRef(
+            self.type2,
+            DataCoordinate.standardize({"instrument": "NotACam", "exposure": 42, "detector": 0},
+                                       universe=universe),
+            run="testRun")
+        self.ref21 = DatasetRef(
+            self.type2,
+            DataCoordinate.standardize({"instrument": "NotACam", "exposure": 42, "detector": 1},
+                                       universe=universe),
+            run="testRun")
+        self.ref30 = DatasetRef(
+            self.type3,
+            DataCoordinate.standardize({"instrument": "NotACam", "exposure": 42, "detector": 0},
+                                       universe=universe),
+            run="testRun")
+        self.ref31 = DatasetRef(
+            self.type3,
+            DataCoordinate.standardize({"instrument": "NotACam", "exposure": 42, "detector": 1},
+                                       universe=universe),
+            run="testRun")
+        self.ref32 = DatasetRef(
+            self.type3,
+            DataCoordinate.standardize({"instrument": "NotACam", "exposure": 42, "detector": 2},
+                                       universe=universe),
+            run="testRun")
+        self.refExp0 = DatasetRef(
+            self.typeE,
+            DataCoordinate.standardize({"instrument": "NotACam", "exposure": 42, "detector": 0},
+                                       universe=universe),
+            run="testRun")
+        # Only safe way to make a component ref
+        self.refPsf0 = self.refExp0.makeComponentRef("psf")
+
+    def _assert_cache_state(self, cache, datasets):
+        """Generic assertion of expected cache contents.
+
+        Parameters
+        ----------
+        cache : `activator.caching.DatasetCache`
+            The cache to test.
+        datasets : mapping [`lsst.daf.butler.DatasetRef`, `bool`]
+            A mapping from dataset refs to whether or not it is expected.
+        """
+        for ref, expected in datasets.items():
+            if expected:
+                self.assertIn(ref, cache)
+            else:
+                self.assertNotIn(ref, cache)
+
+    def test_constructor_initial_state(self):
+        cache = DatasetCache(2, cache_sizes={self.type1: 0, "int2": 1})
+
+        self.assertFalse(cache)
+        self.assertEqual(len(cache), 0)
+        self.assertEqual(list(cache), [])
+
+    def test_constructor_nonnegative(self):
+        with self.assertRaises(ValueError):
+            DatasetCache(-1)
+        DatasetCache(0)
+
+        with self.assertRaises(ValueError):
+            DatasetCache(2, cache_sizes={"int1": -1, "int2": 1})
+        DatasetCache(2, cache_sizes={self.type1: 0, "int2": 1})
+
+    def test_constructor_nocomponents(self):
+        with self.assertRaises(ValueError):
+            DatasetCache(2, cache_sizes={"exp.psf": 1})
+        DatasetCache(2, cache_sizes={"exp": 1})
+
+    # NOTE to maintainers: the following tests make no assumptions about what
+    # eviction strategy DatasetCache is configured with. To test specific
+    # strategies, make separate test cases (likely with a larger cache and a
+    # controlled history of reads).
+
+    def test_update(self):
+        cache = DatasetCache(2, cache_sizes={"int2": 1}, cache_factory=self._cache_factory)
+
+        self._assert_cache_state(
+            cache,
+            {ref: False for ref in [self.ref1, self.ref20, self.ref21, self.ref30, self.ref31, self.ref32,
+                                    self.refExp0]}
+        )
+
+        # Should not evict
+        evicted = cache.update([self.ref1, self.ref20, self.ref30, self.ref31])
+        self.assertFalse(evicted)
+        self._assert_cache_state(cache, {self.ref1: True,
+                                         self.ref20: True,
+                                         self.ref21: False,
+                                         self.ref30: True,
+                                         self.ref31: True,
+                                         self.ref32: False,
+                                         self.refExp0: False,
+                                         })
+
+        # Redundant, should not evict
+        evicted = cache.update([self.ref20])
+        self.assertFalse(evicted)
+        self._assert_cache_state(cache, {self.ref1: True,
+                                         self.ref20: True,
+                                         self.ref21: False,
+                                         self.ref30: True,
+                                         self.ref31: True,
+                                         self.ref32: False,
+                                         self.refExp0: False,
+                                         })
+
+        # Should evict existing int2
+        evicted = cache.update([self.ref21])
+        self.assertEqual(set(evicted), {self.ref20})
+        self._assert_cache_state(cache, {self.ref1: True,
+                                         self.ref20: False,
+                                         self.ref21: True,
+                                         self.ref30: True,
+                                         self.ref31: True,
+                                         self.ref32: False,
+                                         self.refExp0: False,
+                                         })
+
+        # Should evict one of the other int3s
+        evicted = cache.update({self.ref32})
+        self.assertEqual(len(evicted), 1)
+        self.assertLess(set(evicted), {self.ref30, self.ref31})
+        self._assert_cache_state(cache, {self.ref1: True,
+                                         self.ref20: False,
+                                         self.ref21: True,
+                                         self.ref32: True,
+                                         self.refExp0: False,
+                                         })
+        self.assertTrue((self.ref30 in cache) ^ (self.ref31 in cache), msg=f"cache = {cache}")
+        self.assertTrue((self.ref30 in evicted) ^ (self.ref30 in cache),
+                        msg=f"evicted = {evicted}, cache = {cache}")
+        self.assertTrue((self.ref31 in evicted) ^ (self.ref31 in cache),
+                        msg=f"evicted = {evicted}, cache = {cache}")
+
+        # Should cache by parent but allow component retrieval
+        with self.assertRaises(ValueError):
+            cache.update({self.refPsf0})
+        cache.update({self.refExp0})
+        self.assertIn(self.refExp0, cache)
+        self.assertNotIn(self.refPsf0, cache)

--- a/tests/test_evictingSet.py
+++ b/tests/test_evictingSet.py
@@ -1,0 +1,499 @@
+# This file is part of prompt_processing.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import abc
+import unittest
+
+from activator.evictingSet import RandomReplacementSet
+
+
+class EvictingSetTest(metaclass=abc.ABCMeta):
+    @property
+    @abc.abstractmethod
+    def factory(self):
+        """A callable that takes an iterable and returns a test set.
+
+        Parameters
+        ----------
+        max_size : `int`
+            The maximum size of the set.
+        elements : iterable, optional
+            The initial contents of the set, subject to ``max_size``.
+        """
+
+    def test_contains(self):
+        testbed = self.factory(3)
+        self.assertNotIn(3, testbed)
+        self.assertNotIn(2, testbed)
+        self.assertNotIn(42, testbed)
+
+        testbed = self.factory(3, [3, 2])
+        self.assertIn(3, testbed)
+        self.assertIn(2, testbed)
+        self.assertNotIn(42, testbed)
+
+        testbed.add(42)
+        self.assertIn(3, testbed)
+        self.assertIn(2, testbed)
+        self.assertIn(42, testbed)
+
+        # Eviction triggered, only latest entry guaranteed to be present.
+        testbed.add(101)
+        self.assertIn(101, testbed)
+
+    def test_get(self):
+        testbed = self.factory(3)
+        with self.assertRaises(KeyError):
+            testbed.get(3)
+        with self.assertRaises(KeyError):
+            testbed.get(2)
+        with self.assertRaises(KeyError):
+            testbed.get(42)
+
+        testbed = self.factory(3, [3, 2])
+        self.assertEqual(testbed.get(3), 3)
+        self.assertEqual(testbed.get(2), 2)
+        with self.assertRaises(KeyError):
+            testbed.get(42)
+
+        testbed.add(42)
+        self.assertEqual(testbed.get(3), 3)
+        self.assertEqual(testbed.get(2), 2)
+        self.assertEqual(testbed.get(42), 42)
+
+        # Eviction triggered, only latest entry guaranteed to be present.
+        testbed.add(101)
+        self.assertEqual(testbed.get(101), 101)
+
+    def test_iter(self):
+        testbed = self.factory(2)
+        contents = {x for x in testbed}
+        self.assertEqual(contents, set())
+
+        testbed = self.factory(3, [3, 2])
+        contents = {x for x in testbed}
+        self.assertEqual(contents, {3, 2})
+
+        testbed.add(24)
+        contents = {x for x in testbed}
+        self.assertEqual(contents, {3, 2, 24})
+
+        # Eviction triggered, only latest entry guaranteed to be present.
+        testbed.add(101)
+        contents = {x for x in testbed}
+        self.assertEqual(len(contents), 3)
+        self.assertIn(101, contents)
+
+        testbed.remove(101)
+        contents = {x for x in testbed}
+        self.assertEqual(len(contents), 2)
+
+        # Immediate eviction, can only guarantee number of elements.
+        testbed = self.factory(1, [3, 2, 42, 5])
+        contents = {x for x in testbed}
+        self.assertEqual(len(contents), 1)
+
+    def test_len(self):
+        testbed = self.factory(42)
+        self.assertEqual(len(testbed), 0)
+
+        testbed = self.factory(3, [3, 2])
+        self.assertEqual(len(testbed), 2)
+
+        testbed.add(24)
+        self.assertEqual(len(testbed), 3)
+
+        # Eviction triggered.
+        testbed.add(101)
+        self.assertEqual(len(testbed), 3)
+
+        testbed.remove(101)
+        self.assertEqual(len(testbed), 2)
+
+        # Immediate eviction.
+        testbed = self.factory(1, [3, 2, 42, 5])
+        self.assertEqual(len(testbed), 1)
+
+    def test_comparisons(self):
+        self.assertLess(self.factory(5, [2, 3]), {1, 2, 3})
+        self.assertLess(self.factory(5, [2, 3]), self.factory(3, [1, 2, 3]))
+        self.assertLessEqual(self.factory(5, [2, 3]), {1, 2, 3})
+        self.assertLessEqual(self.factory(5, [2, 3]), self.factory(3, [1, 2, 3]))
+        self.assertGreater(self.factory(3, [1, 2, 3]), {2, 3})
+        self.assertGreater(self.factory(3, [1, 2, 3]), self.factory(5, [2, 3]))
+        self.assertGreaterEqual(self.factory(3, [1, 2, 3]), {2, 3})
+        self.assertGreaterEqual(self.factory(3, [1, 2, 3]), self.factory(5, [2, 3]))
+        self.assertFalse(self.factory(3, [1, 2, 3]) < {2, 3})
+        self.assertFalse(self.factory(3, [1, 2, 3]) < self.factory(5, [2, 3]))
+        self.assertFalse(self.factory(5, [2, 3]) > {1, 2, 3})
+        self.assertFalse(self.factory(5, [2, 3]) > self.factory(3, [1, 2, 3]))
+        self.assertFalse(self.factory(3, [1, 2, 3]) <= {2, 3})
+        self.assertFalse(self.factory(3, [1, 2, 3]) <= self.factory(5, [2, 3]))
+        self.assertFalse(self.factory(5, [2, 3]) >= {1, 2, 3})
+        self.assertFalse(self.factory(5, [2, 3]) >= self.factory(3, [1, 2, 3]))
+
+        # Evictions should never add elements.
+        self.assertLess(self.factory(2, [1, 2, 3]), {1, 2, 3})
+        self.assertLess(self.factory(2, [1, 2, 3]), self.factory(5, [1, 2, 3]))
+        self.assertLessEqual(self.factory(2, [1, 2, 3]), {1, 2, 3})
+        self.assertLessEqual(self.factory(2, [1, 2, 3]), self.factory(5, [1, 2, 3]))
+        self.assertFalse(self.factory(5, [1, 2, 3]) < self.factory(3, [1, 2, 3]))
+        self.assertGreater(self.factory(5, [1, 2, 3]), self.factory(2, [1, 2, 3]))
+        self.assertGreaterEqual(self.factory(5, [1, 2, 3]), self.factory(2, [1, 2, 3]))
+
+        self.assertEqual(self.factory(5, [2, 3]), {2, 3})
+        self.assertEqual(self.factory(5, [2, 3]), self.factory(5, [2, 3]))
+        self.assertEqual(self.factory(5, [2, 3]), self.factory(2, [2, 3]))
+        self.assertLessEqual(self.factory(5, [2, 3]), {2, 3})
+        self.assertLessEqual(self.factory(5, [2, 3]), self.factory(5, [2, 3]))
+        self.assertLessEqual(self.factory(5, [2, 3]), self.factory(2, [2, 3]))
+        self.assertGreaterEqual(self.factory(5, [2, 3]), {2, 3})
+        self.assertGreaterEqual(self.factory(5, [2, 3]), self.factory(5, [2, 3]))
+        self.assertGreaterEqual(self.factory(5, [2, 3]), self.factory(2, [2, 3]))
+        self.assertNotEqual(self.factory(5, [2, 3]), self.factory(1, [2, 3]))
+        self.assertFalse(self.factory(5, [2, 3]) != {2, 3})
+        self.assertFalse(self.factory(5, [2, 3]) != self.factory(5, [2, 3]))
+        self.assertFalse(self.factory(5, [2, 3]) != self.factory(2, [2, 3]))
+        self.assertFalse(self.factory(5, [2, 3]) == self.factory(1, [2, 3]))
+
+        self.assertNotEqual(self.factory(5, [2, 3]), {1, 2, 3})
+        self.assertNotEqual(self.factory(5, [2, 3]), self.factory(3, [1, 2, 3]))
+        self.assertFalse(self.factory(5, [2, 3]) == {1, 2, 3})
+        self.assertFalse(self.factory(5, [2, 3]) == self.factory(3, [1, 2, 3]))
+
+        # Disjoint relations (all false) can only be expressed with explicit operators.
+        self.assertFalse(self.factory(3, [10, 12]) < {2, 3})
+        self.assertFalse(self.factory(3, [10, 12]) < self.factory(5, [2, 3]))
+        self.assertFalse(self.factory(3, [10, 12]) <= {2, 3})
+        self.assertFalse(self.factory(3, [10, 12]) <= self.factory(5, [2, 3]))
+        self.assertFalse(self.factory(3, [10, 12]) > {2, 3})
+        self.assertFalse(self.factory(3, [10, 12]) > self.factory(5, [2, 3]))
+        self.assertFalse(self.factory(3, [10, 12]) >= {2, 3})
+        self.assertFalse(self.factory(3, [10, 12]) >= self.factory(5, [2, 3]))
+
+    def test_and(self):
+        testbed = self.factory(3, [2, 3])
+        anded = testbed & {1, 2, 3}
+        anded2 = {1, 2, 3} & testbed
+        testbed &= {1, 2, 3}
+        self.assertIsInstance(anded, type(self.factory(0)))
+        self.assertEqual(anded.max_size, 3)
+        self.assertEqual(anded, {2, 3})
+        self.assertEqual(testbed, anded)
+        self.assertIsInstance(anded2, set)
+        self.assertEqual(anded2, {2, 3})
+
+        testbed = self.factory(2, [2, 3])
+        anded = testbed & self.factory(3, [1, 2])
+        anded2 = self.factory(3, [1, 2]) & testbed
+        testbed &= self.factory(3, [1, 2])
+        self.assertIsInstance(anded, type(self.factory(0)))
+        self.assertEqual(anded.max_size, 2)
+        self.assertEqual(anded, {2})
+        self.assertEqual(testbed, anded)
+        self.assertIsInstance(anded2, type(self.factory(0)))
+        self.assertEqual(anded2.max_size, 3)
+        self.assertEqual(anded2, {2})
+
+        testbed = self.factory(3, [1, 2, 3])
+        anded = testbed & self.factory(2, [10, 11])
+        anded2 = self.factory(2, [10, 11]) & testbed
+        testbed &= self.factory(2, [10, 11])
+        self.assertIsInstance(anded, type(self.factory(0)))
+        self.assertEqual(anded.max_size, 3)
+        self.assertEqual(anded, set())
+        self.assertEqual(testbed, anded)
+        self.assertIsInstance(anded2, type(self.factory(0)))
+        self.assertEqual(anded2.max_size, 2)
+        self.assertEqual(anded2, set())
+
+    def test_or(self):
+        testbed = self.factory(3, [2, 3])
+        ored = testbed | {1, 2, 3}
+        ored2 = {1, 2, 3} | testbed
+        testbed |= {1, 2, 3}
+        self.assertIsInstance(ored, type(self.factory(0)))
+        self.assertEqual(ored.max_size, 3)
+        self.assertEqual(ored, {1, 2, 3})
+        self.assertEqual(testbed, ored)
+        self.assertIsInstance(ored2, set)
+        self.assertEqual(ored2, {1, 2, 3})
+
+        testbed = self.factory(2, [2, 3])
+        ored = testbed | self.factory(3, [1, 2])
+        ored2 = self.factory(3, [1, 2]) | testbed
+        testbed |= self.factory(3, [1, 2])
+        self.assertIsInstance(ored, type(self.factory(0)))
+        self.assertEqual(ored.max_size, 2)
+        # New elements take precedence
+        self.assertEqual(ored, {1, 2})
+        self.assertEqual(testbed, ored)
+        self.assertIsInstance(ored2, type(self.factory(0)))
+        self.assertEqual(ored2.max_size, 3)
+        self.assertEqual(ored2, {1, 2, 3})
+
+        testbed = self.factory(3, [1, 2, 3])
+        ored = testbed | self.factory(2, [10, 11])
+        ored2 = self.factory(2, [10, 11]) | testbed
+        testbed |= self.factory(2, [10, 11])
+        self.assertIsInstance(ored, type(self.factory(0)))
+        self.assertEqual(ored.max_size, 3)
+        self.assertEqual(len(ored), 3)
+        # New elements take precedence
+        self.assertGreater(ored, {10, 11})
+        # testbed need not equal ored if eviction strategy is non-deterministic
+        self.assertEqual(testbed.max_size, 3)
+        self.assertEqual(len(testbed), 3)
+        self.assertGreater(testbed, {10, 11})
+        self.assertIsInstance(ored2, type(self.factory(0)))
+        self.assertEqual(ored2.max_size, 2)
+        self.assertEqual(len(ored2), 2)
+        # New elements take precedence
+        self.assertLess(ored2, {1, 2, 3})
+
+    def test_sub(self):
+        testbed = self.factory(3, [2, 3])
+        diffed = testbed - {1, 2, 3}
+        diffed2 = {1, 2, 3} - testbed
+        testbed -= {1, 2, 3}
+        self.assertIsInstance(diffed, type(self.factory(0)))
+        self.assertEqual(diffed.max_size, 3)
+        self.assertEqual(diffed, set())
+        self.assertEqual(testbed, diffed)
+        self.assertIsInstance(diffed2, set)
+        self.assertEqual(diffed2, {1})
+
+        testbed = self.factory(2, [2, 3])
+        diffed = testbed - self.factory(3, [1, 2])
+        diffed2 = self.factory(3, [1, 2]) - testbed
+        testbed -= self.factory(3, [1, 2])
+        self.assertIsInstance(diffed, type(self.factory(0)))
+        self.assertEqual(diffed.max_size, 2)
+        self.assertEqual(diffed, {3})
+        self.assertEqual(testbed, diffed)
+        self.assertIsInstance(diffed2, type(self.factory(0)))
+        self.assertEqual(diffed2.max_size, 3)
+        self.assertEqual(diffed2, {1})
+
+        testbed = self.factory(3, [1, 2, 3])
+        diffed = testbed - self.factory(2, [10, 11])
+        diffed2 = self.factory(2, [10, 11]) - testbed
+        testbed -= self.factory(2, [10, 11])
+        self.assertIsInstance(diffed, type(self.factory(0)))
+        self.assertEqual(diffed.max_size, 3)
+        self.assertEqual(diffed, {1, 2, 3})
+        self.assertEqual(testbed, diffed)
+        self.assertIsInstance(diffed2, type(self.factory(0)))
+        self.assertEqual(diffed2.max_size, 2)
+        self.assertEqual(diffed2, {10, 11})
+
+    def test_xor(self):
+        testbed = self.factory(3, [2, 3])
+        xored = testbed ^ {1, 2, 3}
+        xored2 = {1, 2, 3} ^ testbed
+        testbed ^= {1, 2, 3}
+        self.assertIsInstance(xored, type(self.factory(0)))
+        self.assertEqual(xored.max_size, 3)
+        self.assertEqual(xored, {1})
+        self.assertEqual(testbed, xored)
+        self.assertIsInstance(xored2, set)
+        self.assertEqual(xored2, {1})
+
+        testbed = self.factory(2, [2, 3])
+        xored = testbed ^ self.factory(3, [1, 2])
+        xored2 = self.factory(3, [1, 2]) ^ testbed
+        testbed ^= self.factory(3, [1, 2])
+        self.assertIsInstance(xored, type(self.factory(0)))
+        self.assertEqual(xored.max_size, 2)
+        self.assertEqual(len(xored), 2)
+        self.assertEqual(xored, {1, 3})
+        self.assertEqual(testbed, xored)
+        self.assertIsInstance(xored2, type(self.factory(0)))
+        self.assertEqual(xored2.max_size, 3)
+        self.assertEqual(xored2, {1, 3})
+
+        testbed = self.factory(2, [2, 3])
+        xored = testbed ^ self.factory(3, [1, 2, 4])
+        xored2 = self.factory(3, [1, 2, 4]) ^ testbed
+        testbed ^= self.factory(3, [1, 2, 4])
+        self.assertIsInstance(xored, type(self.factory(0)))
+        self.assertEqual(xored.max_size, 2)
+        self.assertEqual(len(xored), 2)
+        # New elements take precedence
+        self.assertEqual(xored, {1, 4})
+        self.assertEqual(testbed, xored)
+        self.assertIsInstance(xored2, type(self.factory(0)))
+        self.assertEqual(xored2.max_size, 3)
+        self.assertEqual(xored2, {1, 3, 4})
+
+        testbed = self.factory(3, [1, 2, 3])
+        xored = testbed ^ self.factory(2, [10, 11])
+        xored2 = self.factory(2, [10, 11]) ^ testbed
+        testbed ^= self.factory(2, [10, 11])
+        self.assertIsInstance(xored, type(self.factory(0)))
+        self.assertEqual(xored.max_size, 3)
+        self.assertEqual(len(xored), 3)
+        self.assertLess(xored, {1, 2, 3, 10, 11})
+        # New elements take precedence
+        self.assertGreater(xored, {10, 11})
+        # testbed need not equal xored if eviction strategy is non-deterministic
+        self.assertEqual(testbed.max_size, 3)
+        self.assertEqual(len(testbed), 3)
+        self.assertLess(testbed, {1, 2, 3, 10, 11})
+        self.assertGreater(testbed, {10, 11})
+        self.assertIsInstance(xored2, type(self.factory(0)))
+        self.assertEqual(xored2.max_size, 2)
+        self.assertEqual(len(xored2), 2)
+        # New elements take precedence
+        self.assertLess(xored2, {1, 2, 3})
+
+    def test_isdisjoint(self):
+        self.assertFalse(self.factory(3, [2, 3]).isdisjoint({1, 2, 3}))
+        self.assertFalse(self.factory(2, [2, 3]).isdisjoint(self.factory(3, [1, 2])))
+        self.assertTrue(self.factory(2, [2, 3]).isdisjoint({10, 11}))
+        self.assertTrue(self.factory(2, [2, 3]).isdisjoint(self.factory(2, [10, 11])))
+
+    def test_add(self):
+        testbed = self.factory(2)
+        self.assertEqual(testbed.max_size, 2)
+        self.assertEqual(testbed, set())
+
+        evicted = testbed.add(42)
+        self.assertIsNone(evicted)
+        self.assertEqual(testbed.max_size, 2)
+        self.assertEqual(testbed, {42})
+
+        evicted = testbed.add(32)
+        self.assertIsNone(evicted)
+        self.assertEqual(testbed.max_size, 2)
+        self.assertEqual(testbed, {32, 42})
+
+        evicted = testbed.add(101)
+        self.assertIsNotNone(evicted)
+        self.assertEqual(testbed.max_size, 2)
+        self.assertIn(101, testbed)
+        self.assertEqual(testbed, {32, 42, 101} - {evicted})
+
+        # Duplicate insert should not cause eviction
+        old_state = set(testbed)
+        evicted = testbed.add(101)
+        self.assertIsNone(evicted)
+        self.assertEqual(testbed.max_size, 2)
+        self.assertEqual(testbed, old_state)
+
+    def test_discard(self):
+        testbed = self.factory(3, {32, 42, 102})
+        self.assertEqual(testbed.max_size, 3)
+        self.assertEqual(testbed, {32, 42, 102})
+
+        testbed.discard(42)
+        self.assertEqual(testbed.max_size, 3)
+        self.assertEqual(testbed, {32, 102})
+
+        # Nothing to remove
+        testbed.discard(101)
+        self.assertEqual(testbed.max_size, 3)
+        self.assertEqual(testbed, {32, 102})
+
+        # History of removed datasets should not cause evictions
+        evicted = testbed.add(101)
+        self.assertIsNone(evicted)
+        self.assertEqual(testbed.max_size, 3)
+        self.assertEqual(testbed, {32, 101, 102})
+
+    def test_clear(self):
+        testbed = self.factory(2, {32, 31})
+        self.assertEqual(testbed.max_size, 2)
+        self.assertEqual(testbed, {32, 31})
+
+        testbed.clear()
+        self.assertEqual(testbed.max_size, 2)
+        self.assertEqual(testbed, set())
+
+        # History of removed datasets should not cause evictions
+        evicted = testbed.add(101)
+        self.assertIsNone(evicted)
+        evicted = testbed.add(102)
+        self.assertIsNone(evicted)
+        self.assertEqual(testbed.max_size, 2)
+        self.assertEqual(testbed, {101, 102})
+
+    def pop(self):
+        testbed = self.factory(3, {32, 42, 102})
+        self.assertEqual(testbed.max_size, 3)
+        self.assertEqual(testbed, {32, 42, 102})
+
+        popped = testbed.pop()
+        self.assertEqual(testbed.max_size, 3)
+        self.assertEqual(testbed, {32, 42, 102} - {popped})
+
+        # History of removed datasets should not cause evictions
+        evicted = testbed.add(101)
+        self.assertIsNone(evicted)
+        self.assertEqual(testbed.max_size, 3)
+        self.assertEqual(testbed, {32, 42, 101, 102} - {popped})
+
+        testbed = self.factory(2)
+        self.assertEqual(testbed, set())
+        with self.assertRaises(KeyError):
+            testbed.pop()
+
+    def test_remove(self):
+        testbed = self.factory(3, {32, 42, 102})
+        self.assertEqual(testbed.max_size, 3)
+        self.assertEqual(testbed, {32, 42, 102})
+
+        testbed.remove(42)
+        self.assertEqual(testbed.max_size, 3)
+        self.assertEqual(testbed, {32, 102})
+
+        with self.assertRaises(KeyError):
+            testbed.remove(101)
+
+        # History of removed datasets should not cause evictions
+        evicted = testbed.add(101)
+        self.assertIsNone(evicted)
+        self.assertEqual(testbed.max_size, 3)
+        self.assertEqual(testbed, {32, 101, 102})
+
+
+class RandomReplacementSetTest(unittest.TestCase, EvictingSetTest):
+    @property
+    def factory(self):
+        def make_set(max_size, elements=frozenset()):
+            # Variable seed gives better coverage of edge cases.
+            return RandomReplacementSet(max_size, elements, seed=abs(hash(self.id())))
+        return make_set
+
+    def test_constructor(self):
+        # Legal, if of dubious utility
+        testbed = RandomReplacementSet(0)
+        self.assertFalse(testbed)
+        testbed.add(42)
+        self.assertFalse(testbed)
+
+        with self.assertRaises(ValueError):
+            RandomReplacementSet(-1)
+
+        testbed = RandomReplacementSet(2, {1, 2, 3, 4, 5})
+        self.assertTrue(testbed)
+        self.assertEqual(len(testbed), 2)
+        self.assertLess(testbed, {1, 2, 3, 4, 5})


### PR DESCRIPTION
This PR adds a dataset cache to ensure the local repo never exceeds a configured size. The implementation is quite messy and may need to be replaced later, but the basic configuration hooks should be permanent.