### PR TITLE
DM-43180: Include private_efdStamp in test messages.

### DIFF
--- a/python/tester/upload.py
+++ b/python/tester/upload.py
@@ -84,7 +84,10 @@ def process_group(kafka_url, visit_infos, uploader):
     for info in visit_infos:
         group = info.groupId
         n_snaps = info.nimages
-        visit = SummitVisit(**info.get_bare_visit(), private_sndStamp=info.private_sndStamp)
+        visit = SummitVisit(**info.get_bare_visit(),
+                            private_sndStamp=info.private_sndStamp,
+                            private_efdStamp=astropy.time.Time(info.private_sndStamp, format="unix_tai").unix,
+                            )
         send_next_visit(kafka_url, group, {visit})
         break
     else:

--- a/python/tester/upload_from_repo.py
+++ b/python/tester/upload_from_repo.py
@@ -230,6 +230,7 @@ def prepare_one_visit(kafka_url, group_id, butler, instrument, visit_id):
             duration=duration,
             totalCheckpoints=1,
             private_sndStamp=data_id.records["exposure"].timespan.begin.unix_tai-2*duration,
+            private_efdStamp=data_id.records["exposure"].timespan.begin.unix-2*duration,
         )
         send_next_visit(kafka_url, group_id, {visit})
 


### PR DESCRIPTION
This timestamp is used by the fan-out service in lsst-dm/next_visit_fan_out#13, and must be merged first.