### PR TITLE
DM-43648: Old repos left behind on Prompt Processing worker reboot

### DIFF
--- a/.github/workflows/build-service.yml
+++ b/.github/workflows/build-service.yml
@@ -96,7 +96,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Determine eups tag
         run: |
-          docker run ghcr.io/${{ github.repository_owner }}/prompt-base:"$BASE_TAG" bash -c "cat stack/miniconda*/ups_db/global.tags" > eups.tag
+          docker run ghcr.io/${{ github.repository_owner }}/prompt-base:"$BASE_TAG" bash -c "cat stack/miniconda*/ups_db/global.tags" > eups.tag || echo "Unknown" > eups.tag
           echo "Eups tag = $(< eups.tag)"
       - name: Build image
         run: |
@@ -122,7 +122,7 @@ jobs:
             docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
             docker push $IMAGE_ID:$VERSION
             EUPS_TAG=$(< eups.tag)
-            if [ "$BASE_TAG" != "$EUPS_TAG" ]; then
+            if [ "$EUPS_TAG" != "Unknown" && "$BASE_TAG" != "$EUPS_TAG" ]; then
               if [ "$BRANCH" == "main" ]; then
                 VERSION="$EUPS_TAG"
               else


### PR DESCRIPTION
This PR adds a startup check that removes any prior local repos (from a killed worker) that may be taking up space. This prevents worker failures from cascading to later requests.

If the local repo cannot be removed, the preferred solution is to abort startup entirely; killing and replacing the pod is slow, but guarantees a clean slate.