### PR TITLE
DM-45084: Quick-container fix breaks tagging of regular Prompt Processing containers

### DIFF
--- a/.github/workflows/build-service.yml
+++ b/.github/workflows/build-service.yml
@@ -122,7 +122,7 @@ jobs:
             docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
             docker push $IMAGE_ID:$VERSION
             EUPS_TAG=$(< eups.tag)
-            if [ "$EUPS_TAG" != "Unknown" && "$BASE_TAG" != "$EUPS_TAG" ]; then
+            if [ "$EUPS_TAG" != "Unknown" ] && [ "$BASE_TAG" != "$EUPS_TAG" ]; then
               if [ "$BRANCH" == "main" ]; then
                 VERSION="$EUPS_TAG"
               else


### PR DESCRIPTION
This PR fixes invalid shell syntax in `build-service.yml`. It's not clear why the action ran successfully instead of erroring out.