### PR TITLE
Clarify that we can ignore ApdbCassandraReplica version.

### DIFF
--- a/doc/playbook.rst
+++ b/doc/playbook.rst
@@ -116,6 +116,7 @@ Add text as follows.
 * Any specific motivation for the release (for example, including a specific feature, preparing for a specific observing run)
 * Science Pipelines version and rubin-env version
 * Supported `APDB schema`_ and `ApdbSql`_/`ApdbCassandra`_ versions (see `DMTN-269`_ for rationale).
+  You do *not* need to consider the `ApdbCassandraReplica` version.
   A stack quoting a given minor version is compatible with *older* APDBs of that major version but not necessarily newer ones; for example, a release whose baseline is APDB schema 1.4.0 can access a schema 1.0.0 or 1.4.1 database, but not schema 1.5.
 * Supported `Butler dimensions-config`_ versions
 * The `Alerts schema`_ version used for output (see `DMTN-093`_ for details)


### PR DESCRIPTION
PP does not interact with the "replica" schema, and so is neither compatible nor incompatible with any particular version.