### PR TITLE
DM-45199: Support multiple workers per Prompt Processing pod

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 # Include these paths.
 !python/activator/*.py
 !pipelines
+!config/gunicorn.conf.py

--- a/.github/workflows/build-service.yml
+++ b/.github/workflows/build-service.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - '.github/workflows/build-service.yml'
+      - 'config/**'
       - 'pipelines/**'
       - 'python/activator/**'
       - 'tests/**'
@@ -13,6 +14,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/build-service.yml'
+      - 'config/**'
       - 'pipelines/**'
       - 'python/activator/**'
       - 'tests/**'

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ ARG PORT
 WORKDIR $APP_HOME
 COPY python/activator activator/
 COPY pipelines pipelines/
+COPY config/gunicorn.conf.py ./
 CMD source /opt/lsst/software/stack/loadLSST.bash \
     && setup lsst_distrib \
     && exec gunicorn --workers 1 --threads 1 --timeout $WORKER_TIMEOUT --max-requests $WORKER_RESTART_FREQ \
         --graceful-timeout $WORKER_GRACE_PERIOD \
-        --bind :$PORT 'activator.activator:create_app()'
+        --bind :$PORT --config gunicorn.conf.py 'activator.activator:create_app()'

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,4 @@ CMD source /opt/lsst/software/stack/loadLSST.bash \
     && setup lsst_distrib \
     && exec gunicorn --workers 1 --threads 1 --timeout $WORKER_TIMEOUT --max-requests $WORKER_RESTART_FREQ \
         --graceful-timeout $WORKER_GRACE_PERIOD \
-        --bind :$PORT activator.activator:app
+        --bind :$PORT 'activator.activator:create_app()'

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,6 @@ FROM ghcr.io/lsst-dm/prompt-base:${BASE_TAG}
 ENV PYTHONUNBUFFERED=True
 ENV APP_HOME=/app
 ENV PROMPT_PROCESSING_DIR=$APP_HOME
-# Normally defined in the Kubernetes config.
-ENV WORKER_RESTART_FREQ=${WORKER_RESTART_FREQ:-0}
-ENV WORKER_TIMEOUT=${WORKER_TIMEOUT:-0}
-ENV WORKER_GRACE_PERIOD=${WORKER_GRACE_PERIOD:-30}
 ARG PORT
 WORKDIR $APP_HOME
 COPY python/activator activator/
@@ -14,6 +10,4 @@ COPY pipelines pipelines/
 COPY config/gunicorn.conf.py ./
 CMD source /opt/lsst/software/stack/loadLSST.bash \
     && setup lsst_distrib \
-    && exec gunicorn --workers 1 --threads 1 --timeout $WORKER_TIMEOUT --max-requests $WORKER_RESTART_FREQ \
-        --graceful-timeout $WORKER_GRACE_PERIOD \
-        --bind :$PORT --config gunicorn.conf.py 'activator.activator:create_app()'
+    && exec gunicorn --bind :$PORT --config gunicorn.conf.py 'activator.activator:create_app()'

--- a/config/gunicorn.conf.py
+++ b/config/gunicorn.conf.py
@@ -1,0 +1,26 @@
+import shutil
+
+import activator.repo_tracker
+
+
+# Hooks run on the master process
+# -------------------------------
+
+def when_ready(server):
+    tracker = activator.repo_tracker.LocalRepoTracker.get()
+    tracker.init_tracker()
+
+
+def child_exit(server, worker):
+    tracker = activator.repo_tracker.LocalRepoTracker.get()
+    repo = tracker.pop(worker.pid)
+    try:
+        shutil.rmtree(repo)
+    except FileNotFoundError:
+        pass
+    # Propagate all other exceptions; it means the repo is still around!
+
+
+def on_exit(server):
+    tracker = activator.repo_tracker.LocalRepoTracker.get()
+    tracker.cleanup_tracker()

--- a/config/gunicorn.conf.py
+++ b/config/gunicorn.conf.py
@@ -7,12 +7,11 @@ import activator.repo_tracker
 # Config options
 # --------------
 
-workers = 1
-
 threads = 1
 worker_class = "sync"
 
 # Normally defined in the Kubernetes config
+workers = int(os.environ.get("WORKER_COUNT", 1))
 graceful_timeout = int(os.environ.get("WORKER_GRACE_PERIOD", 30))
 timeout = int(os.environ.get("WORKER_TIMEOUT", 0))
 max_requests = int(os.environ.get("WORKER_RESTART_FREQ", 0))

--- a/config/gunicorn.conf.py
+++ b/config/gunicorn.conf.py
@@ -1,6 +1,21 @@
+import os
 import shutil
 
 import activator.repo_tracker
+
+
+# Config options
+# --------------
+
+workers = 1
+
+threads = 1
+worker_class = "sync"
+
+# Normally defined in the Kubernetes config
+graceful_timeout = int(os.environ.get("WORKER_GRACE_PERIOD", 30))
+timeout = int(os.environ.get("WORKER_TIMEOUT", 0))
+max_requests = int(os.environ.get("WORKER_RESTART_FREQ", 0))
 
 
 # Hooks run on the master process

--- a/doc/playbook.rst
+++ b/doc/playbook.rst
@@ -414,7 +414,7 @@ Then in the pod:
    source /opt/lsst/software/stack/loadLSST.bash
 
 The local repo is a directory of the form ``/tmp/butler-????????``.
-There should be only one local repo per ``MiddlewareInterface`` object, and at the time of writing there should be only one such object per pod.
+There should be only one local repo per ``MiddlewareInterface`` object, though each ready worker may have its own repo.
 If in doubt, check the logs first.
 
 

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -23,6 +23,7 @@ __all__ = ["next_visit_handler"]
 
 import collections.abc
 import contextlib
+import functools
 import json
 import logging
 import os
@@ -165,6 +166,7 @@ def with_signal(signum: int,
         The handler to register.
     """
     def decorator(func):
+        @functools.wraps(func)
         def wrapper(*args, **kwargs):
             old_handler = signal.signal(signum, handler)
             try:

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -347,7 +347,7 @@ def next_visit_handler() -> tuple[str, int]:
         try:
             expected_visit = parse_next_visit(flask.request)
         except ValueError as msg:
-            _log.warn(f"error: '{msg}'")
+            _log.exception()
             return f"Bad Request: {msg}", 400
         process_visit(expected_visit)
         return "Pipeline executed", 200

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -51,7 +51,6 @@ from .raw import (
 )
 from .visit import FannedOutVisit
 
-PROJECT_ID = "prompt-processing"
 
 # The short name for the instrument.
 instrument_name = os.environ["RUBIN_INSTRUMENT"]

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -36,7 +36,7 @@ import boto3
 from botocore.handlers import validate_bucket_name
 import cloudevents.http
 import confluent_kafka as kafka
-from flask import Flask, request
+import flask
 from werkzeug.exceptions import ServiceUnavailable
 
 from .config import PipelinesConfig
@@ -158,7 +158,7 @@ def create_app():
             _log.warning("Orphaned repo found at %s, attempting to remove.", old_repo)
             flush_local_repo(old_repo, _get_central_butler())
 
-        app = Flask(__name__)
+        app = flask.Flask(__name__)
         app.add_url_rule("/next-visit", view_func=next_visit_handler, methods=["POST"])
         app.register_error_handler(500, server_error)
         _log.info("Worker ready to handle requests.")
@@ -326,13 +326,11 @@ def _try_export(mwi: MiddlewareInterface, exposures: set[int], log: logging.Logg
         return False
 
 
-@with_signal(signal.SIGHUP, _graceful_shutdown)
-@with_signal(signal.SIGTERM, _graceful_shutdown)
 def next_visit_handler() -> tuple[str, int]:
     """A Flask view function for handling next-visit events.
 
     Like all Flask handlers, this function accepts input through the
-    ``request`` global rather than parameters.
+    ``flask.request`` global rather than parameters.
 
     Returns
     -------
@@ -341,10 +339,44 @@ def next_visit_handler() -> tuple[str, int]:
     status : `int`
         The HTTP response status code to return to the client.
     """
-    _log.info(f"Starting next_visit_handler for {request}.")
-    with contextlib.ExitStack() as cleanups:
+    _log.info(f"Starting next_visit_handler for {flask.request}.")
+
+    try:
+        try:
+            expected_visit = parse_next_visit(flask.request)
+        except ValueError as msg:
+            _log.warn(f"error: '{msg}'")
+            return f"Bad Request: {msg}", 400
+        return process_visit(expected_visit)
+    except GracefulShutdownInterrupt:
+        # Safety net to minimize chance of interrupt propagating out of the worker.
+        # Ideally, this would be a Flask.errorhandler, but Flask ignores BaseExceptions.
+        _log.error("Service interrupted. Shutting down *without* syncing to the central repo.")
+        return "The worker was interrupted before it could complete the request. " \
+               "Retrying the request may not be safe.", 500
+    finally:
         # Want to know when the handler exited for any reason.
-        cleanups.callback(_log.info, "next_visit handling completed.")
+        _log.info("next_visit handling completed.")
+
+
+@with_signal(signal.SIGHUP, _graceful_shutdown)
+@with_signal(signal.SIGTERM, _graceful_shutdown)
+def process_visit(expected_visit: FannedOutVisit) -> tuple[str, int]:
+    """Prepare and run a pipeline on a nextVisit message.
+
+    Parameters
+    ----------
+    expected_visit : `activator.visit.FannedOutVisit`
+        The visit to process.
+
+    Returns
+    -------
+    message : `str`
+        The HTTP response reason to return to the client.
+    status : `int`
+        The HTTP response status code to return to the client.
+    """
+    with contextlib.ExitStack() as cleanups:
         consumer = _get_consumer()
         consumer.subscribe([bucket_topic])
         cleanups.callback(consumer.unsubscribe)
@@ -352,151 +384,139 @@ def next_visit_handler() -> tuple[str, int]:
         # Try to get a message right away to minimize race conditions
         startup_response = consumer.consume(num_messages=1, timeout=0.001)
 
-        try:
+        assert expected_visit.instrument == instrument_name, \
+            f"Expected {instrument_name}, received {expected_visit.instrument}."
+        if not main_pipelines.get_pipeline_files(expected_visit):
+            _log.info(f"No pipeline configured for {expected_visit}, skipping.")
+            return "No pipeline configured for the received visit.", 422
+
+        log_factory = logging.getLogRecordFactory()
+        with log_factory.add_context(group=expected_visit.groupId,
+                                     survey=expected_visit.survey,
+                                     detector=expected_visit.detector,
+                                     ):
             try:
-                expected_visit = parse_next_visit(request)
-            except ValueError as msg:
-                _log.warn(f"error: '{msg}'")
-                return f"Bad Request: {msg}", 400
-            assert expected_visit.instrument == instrument_name, \
-                f"Expected {instrument_name}, received {expected_visit.instrument}."
-            if not main_pipelines.get_pipeline_files(expected_visit):
-                _log.info(f"No pipeline configured for {expected_visit}, skipping.")
-                return "No pipeline configured for the received visit.", 422
+                expid_set = set()
 
-            log_factory = logging.getLogRecordFactory()
-            with log_factory.add_context(group=expected_visit.groupId,
-                                         survey=expected_visit.survey,
-                                         detector=expected_visit.detector,
-                                         ):
-                try:
-                    expid_set = set()
+                # Create a fresh MiddlewareInterface object to avoid accidental
+                # "cross-talk" between different visits.
+                mwi = MiddlewareInterface(_get_central_butler(),
+                                          image_bucket,
+                                          expected_visit,
+                                          pre_pipelines,
+                                          main_pipelines,
+                                          skymap,
+                                          _get_local_repo().name,
+                                          _get_local_cache())
+                # TODO: pipeline execution requires a clean run until DM-38041.
+                cleanups.callback(mwi.clean_local_repo, expid_set)
+                # Copy calibrations for this detector/visit
+                mwi.prep_butler()
 
-                    # Create a fresh MiddlewareInterface object to avoid accidental
-                    # "cross-talk" between different visits.
-                    mwi = MiddlewareInterface(_get_central_butler(),
-                                              image_bucket,
-                                              expected_visit,
-                                              pre_pipelines,
-                                              main_pipelines,
-                                              skymap,
-                                              _get_local_repo().name,
-                                              _get_local_cache())
-                    # TODO: pipeline execution requires a clean run until DM-38041.
-                    cleanups.callback(mwi.clean_local_repo, expid_set)
-                    # Copy calibrations for this detector/visit
-                    mwi.prep_butler()
+                # expected_visit.nimages == 0 means "not known in advance"; keep listening until timeout
+                expected_snaps = expected_visit.nimages if expected_visit.nimages else 100
+                # Heuristic: take the upcoming script's duration and multiply by 2 to
+                # include the currently executing script, then add time to transfer
+                # the last image.
+                timeout = expected_visit.duration * 2 + image_timeout
+                # Check to see if any snaps have already arrived
+                for snap in range(expected_snaps):
+                    oid = check_for_snap(
+                        _get_storage_client(),
+                        image_bucket,
+                        raw_microservice,
+                        expected_visit.instrument,
+                        expected_visit.groupId,
+                        snap,
+                        expected_visit.detector,
+                    )
+                if oid:
+                    _log.debug("Found object %s already present", oid)
+                    exp_id = mwi.ingest_image(oid)
+                    expid_set.add(exp_id)
 
-                    # expected_visit.nimages == 0 means "not known in advance"; keep listening until timeout
-                    expected_snaps = expected_visit.nimages if expected_visit.nimages else 100
-                    # Heuristic: take the upcoming script's duration and multiply by 2 to
-                    # include the currently executing script, then add time to transfer
-                    # the last image.
-                    timeout = expected_visit.duration * 2 + image_timeout
-                    # Check to see if any snaps have already arrived
-                    for snap in range(expected_snaps):
-                        oid = check_for_snap(
-                            _get_storage_client(),
-                            image_bucket,
-                            raw_microservice,
-                            expected_visit.instrument,
-                            expected_visit.groupId,
-                            snap,
-                            expected_visit.detector,
-                        )
-                    if oid:
-                        _log.debug("Found object %s already present", oid)
-                        exp_id = mwi.ingest_image(oid)
-                        expid_set.add(exp_id)
+                _log.debug("Waiting for snaps...")
+                start = time.time()
+                while len(expid_set) < expected_snaps and time.time() - start < timeout:
+                    if startup_response:
+                        response = startup_response
+                    else:
+                        time_remaining = max(0.0, timeout - (time.time() - start))
+                        response = consumer.consume(num_messages=1, timeout=time_remaining + 1.0)
+                    end = time.time()
+                    messages = _filter_messages(response)
+                    response = []
+                    if len(messages) == 0 and end - start < timeout and not startup_response:
+                        _log.debug(f"Empty consume after {end - start}s.")
+                        continue
+                    startup_response = []
 
-                    _log.debug("Waiting for snaps...")
-                    start = time.time()
-                    while len(expid_set) < expected_snaps and time.time() - start < timeout:
-                        if startup_response:
-                            response = startup_response
-                        else:
-                            time_remaining = max(0.0, timeout - (time.time() - start))
-                            response = consumer.consume(num_messages=1, timeout=time_remaining + 1.0)
-                        end = time.time()
-                        messages = _filter_messages(response)
-                        response = []
-                        if len(messages) == 0 and end - start < timeout and not startup_response:
-                            _log.debug(f"Empty consume after {end - start}s.")
-                            continue
-                        startup_response = []
-
-                        # Not all notifications are for this group/detector
-                        for received in messages:
-                            for oid in _parse_bucket_notifications(received.value()):
-                                try:
-                                    if is_path_consistent(oid, expected_visit):
-                                        _log.debug("Received %r", oid)
-                                        group_id = get_group_id_from_oid(oid)
-                                        if group_id == expected_visit.groupId:
-                                            # Ingest the snap
-                                            exp_id = mwi.ingest_image(oid)
-                                            expid_set.add(exp_id)
-                                except ValueError:
-                                    _log.error(f"Failed to match object id '{oid}'")
-                            # Commits are per-group, so this can't interfere with other
-                            # workers. This may wipe messages associated with a next_visit
-                            # that will later be assigned to this worker, but those cases
-                            # should be caught by the "already arrived" check.
-                            consumer.commit(message=received)
-                    if len(expid_set) < expected_snaps:
-                        _log.warning(f"Timed out waiting for image after receiving exposures {expid_set}.")
-                except GracefulShutdownInterrupt as e:
-                    _log.exception("Processing interrupted before pipeline execution")
-                    # Do not export, to leave room for the next attempt
-                    # Service unavailable is not quite right, but no better standard response
-                    raise ServiceUnavailable(f"The server aborted processing, but it can be retried: {e}",
-                                             retry_after=10) from None
-
-                if expid_set:
-                    with log_factory.add_context(exposures=expid_set):
-                        # Got at least some snaps; run the pipeline.
-                        # If this is only a partial set, the processed results may still be
-                        # useful for quality purposes.
-                        # If nimages == 0, any positive number of snaps is OK.
-                        if len(expid_set) < expected_visit.nimages:
-                            _log.warning(f"Processing {len(expid_set)} snaps, "
-                                         f"expected {expected_visit.nimages}.")
-                        _log.info("Running pipeline...")
-                        try:
-                            mwi.run_pipeline(expid_set)
+                    # Not all notifications are for this group/detector
+                    for received in messages:
+                        for oid in _parse_bucket_notifications(received.value()):
                             try:
-                                # TODO: broadcast alerts here
-                                mwi.export_outputs(expid_set)
-                            except Exception as e:
-                                raise NonRetriableError("APDB and possibly alerts or central repo modified") \
-                                    from e
-                        except RetriableError as e:
-                            error = e.nested if e.nested else e
-                            _log.error("Processing failed but can be retried: ", exc_info=error)
-                            # Do not export, to leave room for the next attempt
-                            # Service unavailable is not quite right, but no better standard response
-                            raise ServiceUnavailable(f"A temporary error occurred during processing: {error}",
-                                                     retry_after=10) from None
-                        except NonRetriableError as e:
-                            error = e.nested if e.nested else e
-                            _log.error("Processing failed: ", exc_info=error)
-                            _try_export(mwi, expid_set, _log)
-                            return f"An error occurred during processing: {error}.\nThe system's state has " \
-                                   "permanently changed, so this request should **NOT** be retried.", 500
+                                if is_path_consistent(oid, expected_visit):
+                                    _log.debug("Received %r", oid)
+                                    group_id = get_group_id_from_oid(oid)
+                                    if group_id == expected_visit.groupId:
+                                        # Ingest the snap
+                                        exp_id = mwi.ingest_image(oid)
+                                        expid_set.add(exp_id)
+                            except ValueError:
+                                _log.error(f"Failed to match object id '{oid}'")
+                        # Commits are per-group, so this can't interfere with other
+                        # workers. This may wipe messages associated with a next_visit
+                        # that will later be assigned to this worker, but those cases
+                        # should be caught by the "already arrived" check.
+                        consumer.commit(message=received)
+                if len(expid_set) < expected_snaps:
+                    _log.warning(f"Timed out waiting for image after receiving exposures {expid_set}.")
+            except GracefulShutdownInterrupt as e:
+                _log.exception("Processing interrupted before pipeline execution")
+                # Do not export, to leave room for the next attempt
+                # Service unavailable is not quite right, but no better standard response
+                raise ServiceUnavailable(f"The server aborted processing, but it can be retried: {e}",
+                                         retry_after=10) from None
+
+            if expid_set:
+                with log_factory.add_context(exposures=expid_set):
+                    # Got at least some snaps; run the pipeline.
+                    # If this is only a partial set, the processed results may still be
+                    # useful for quality purposes.
+                    # If nimages == 0, any positive number of snaps is OK.
+                    if len(expid_set) < expected_visit.nimages:
+                        _log.warning(f"Processing {len(expid_set)} snaps, "
+                                     f"expected {expected_visit.nimages}.")
+                    _log.info("Running pipeline...")
+                    try:
+                        mwi.run_pipeline(expid_set)
+                        try:
+                            # TODO: broadcast alerts here
+                            mwi.export_outputs(expid_set)
                         except Exception as e:
-                            _log.error("Processing failed: ", exc_info=e)
-                            _try_export(mwi, expid_set, _log)
-                            return f"An error occurred during processing: {e}.", 500
-                        return "Pipeline executed", 200
-                else:
-                    _log.error("Timed out waiting for images.")
-                    return "Timed out waiting for images", 500
-        except GracefulShutdownInterrupt:
-            # Safety net to minimize chance of interrupt propagating out of the worker.
-            # Ideally, this would be a Flask.errorhandler, but Flask ignores BaseExceptions.
-            _log.error("Service interrupted. Shutting down *without* syncing to the central repo.")
-            return "The worker was interrupted before it could complete the request. " \
-                   "Retrying the request may not be safe.", 500
+                            raise NonRetriableError("APDB and possibly alerts or central repo modified") \
+                                from e
+                    except RetriableError as e:
+                        error = e.nested if e.nested else e
+                        _log.error("Processing failed but can be retried: ", exc_info=error)
+                        # Do not export, to leave room for the next attempt
+                        # Service unavailable is not quite right, but no better standard response
+                        raise ServiceUnavailable(f"A temporary error occurred during processing: {error}",
+                                                 retry_after=10) from None
+                    except NonRetriableError as e:
+                        error = e.nested if e.nested else e
+                        _log.error("Processing failed: ", exc_info=error)
+                        _try_export(mwi, expid_set, _log)
+                        return f"An error occurred during processing: {error}.\nThe system's state has " \
+                               "permanently changed, so this request should **NOT** be retried.", 500
+                    except Exception as e:
+                        _log.error("Processing failed: ", exc_info=e)
+                        _try_export(mwi, expid_set, _log)
+                        return f"An error occurred during processing: {e}.", 500
+                    return "Pipeline executed", 200
+            else:
+                _log.error("Timed out waiting for images.")
+                return "Timed out waiting for images", 500
 
 
 def server_error(e) -> tuple[str, int]:

--- a/python/activator/exception.py
+++ b/python/activator/exception.py
@@ -20,7 +20,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
-__all__ = ["NonRetriableError", "RetriableError", "GracefulShutdownInterrupt"]
+__all__ = ["NonRetriableError", "RetriableError", "GracefulShutdownInterrupt", "InvalidVisitError"]
 
 
 class NonRetriableError(Exception):
@@ -82,4 +82,15 @@ class GracefulShutdownInterrupt(BaseException):
     Like all interrupts, ``GracefulShutdownInterrupt`` can be raised between
     *any* two bytecode instructions, and handling it requires special care. See
     `the Python docs <https://docs.python.org/3.11/library/signal.html#handlers-and-exceptions>`__.
+    """
+
+
+class InvalidVisitError(ValueError):
+    """An exception raised if a visit object has invalid or inappropriate
+    fields.
+
+    See Also
+    --------
+    activator.visit.SummitVisit
+    activator.visit.FannedOutVisit
     """

--- a/python/activator/repo_tracker.py
+++ b/python/activator/repo_tracker.py
@@ -1,0 +1,266 @@
+# This file is part of prompt_processing.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+"""A mapping of which local repos are owned by which workers.
+
+This module is designed to be imported from within a Gunicorn server hook. As
+such, it must be as minimal as possible, have no side effects, and avoid
+expensive imports like `lsst`.
+"""
+
+
+__all__ = ["LocalRepoTracker"]
+
+
+import collections.abc
+import contextlib
+import fcntl
+import logging
+import os.path
+import typing
+
+
+_log = logging.getLogger("lsst." + __name__)
+_log.setLevel(logging.DEBUG)
+
+
+class LocalRepoTracker:
+    """A mapping of process IDs to repo locations.
+
+    This class works only with directories, and has no knowledge of the
+    Butler itself.
+
+    Notes
+    -----
+    This class is process-safe; ``LocalRepoTracker`` objects in different
+    processes all refer to a shared backend.
+    """
+    _instance: typing.Self | None = None
+
+    _BACKEND_FILE = os.path.join(os.path.expanduser("~"), ".repo.tracker.csv")
+
+    @staticmethod
+    def get() -> typing.Self:
+        """Return the tracker."""
+        if LocalRepoTracker._instance is None:
+            LocalRepoTracker._instance = LocalRepoTracker()
+        return LocalRepoTracker._instance
+
+    def init_tracker(self):
+        """Prepare the tracker for use.
+
+        This method should be called by the parent process of any processes
+        that will use the tracker, or at least a process that is guaranteed
+        to outlast the client processes.
+        """
+        with self._open_exclusive(self._BACKEND_FILE, mode="x") as f:
+            self._write_data(f, {})
+        _log.info("Local repo tracker is ready for use.")
+
+    def cleanup_tracker(self):
+        """Remove the tracker and delete all state.
+        """
+        try:
+            os.remove(self._BACKEND_FILE)
+        except FileNotFoundError:
+            pass
+        _log.info("Local repo tracker has been cleaned up.")
+
+    @staticmethod
+    @contextlib.contextmanager
+    def _open_exclusive(*args, **kwargs):
+        """Open a file with exclusive locking.
+
+        This method blocks if the file is already held by another process.
+        Locks are **not** re-entrant.
+
+        Parameters
+        ----------
+        *args, **kwargs
+            Arguments, interpreted as for `open`.
+
+        Yields
+        ------
+        file : file object
+            The open file.
+        """
+        with open(*args, **kwargs) as open_file:
+            fcntl.flock(open_file, fcntl.LOCK_EX)
+            try:
+                yield open_file
+            finally:
+                # Mostly for redundancy -- flock guarantees that the lock is
+                # released if the file descriptor is closed.
+                fcntl.flock(open_file, fcntl.LOCK_UN)
+
+    def _read_data(self, file) -> collections.abc.Mapping[int, str]:
+        """Load the current tracker state.
+
+        Parameters
+        ----------
+        file : file object
+            The file backing the tracker.
+
+        Returns
+        -------
+        data : mapping [`int`, `str`]
+            A mapping from process IDs to the associated local repo.
+
+        Note
+        ----
+        This method is not process-safe.
+        """
+        data = {}
+        line = file.readline().strip()
+        while line != "":
+            id, repo = line.split(",", maxsplit=1)
+            data[int(id)] = repo
+            line = file.readline().strip()
+        return data
+
+    def _write_data(self, file, data: collections.abc.Mapping[int, str]):
+        """Set the tracker state.
+
+        This method overwrites the contents of the backend with ``data``
+        instead of merging them.
+
+        Parameters
+        ----------
+        file : file object
+            The file backing the tracker.
+        data : mapping [`int`, `str`]
+            The mapping from process IDs to the associated local repo to store.
+
+        Note
+        ----
+        This method is not process-safe.
+        """
+        file.seek(0)
+        file.truncate()
+        file.writelines(f"{pid},{repo}\n" for pid, repo in data.items())
+
+    K = typing.TypeVar('K')
+    V = typing.TypeVar('V')
+
+    @staticmethod
+    def _reverse_lookup(mapping: collections.abc.Mapping[K, V], value: V) -> K:
+        """Look up a key by its corresponding value.
+
+        Parameters
+        ----------
+        mapping
+            The mapping to search.
+        value
+            The value to look up.
+
+        Returns
+        -------
+        key
+            A key that maps to ``value``. If there is more than one such key,
+            which one is returned is undefined.
+        """
+        for key, kvalue in mapping.items():
+            if value == kvalue:
+                return key
+        raise KeyError(f"No key maps to {value}.")
+
+    def register(self, pid: int, repo: str):
+        """Add a repository to the tracker.
+
+        Parameters
+        ----------
+        pid : `int`
+            The process ID responsible for the repo.
+        repo : `str`
+            The canonical path to the repo.
+
+        Raises
+        ------
+        ValueError
+            Raised if the tracker already has an entry for ``pid`` or ``repo``.
+        """
+        with self._open_exclusive(self._BACKEND_FILE, mode="r+") as f:
+            data = self._read_data(f)
+
+            if pid in data:
+                raise ValueError(f"Pid {pid} already owns {data[pid]}.")
+            if repo in data.values():
+                raise ValueError(f"Repo {repo} is already owned by "
+                                 f"pid {self._reverse_lookup(data, repo)}.")
+
+            data[pid] = repo
+            self._write_data(f, data)
+        _log.info("Registered %s to process %d.", repo, pid)
+
+    def pop(self, pid: int) -> str:
+        """Unregister a repository.
+
+        Parameters
+        ----------
+        pid : `int`
+            The process ID responsible for the repo.
+
+        Returns
+        -------
+        repo: `str`
+            The popped repo.
+
+        Raises
+        ------
+        ValueError
+            Raised if there is no repo for ``pid``.
+        """
+        with self._open_exclusive(self._BACKEND_FILE, mode="r+") as f:
+            data = self._read_data(f)
+            try:
+                repo = data.pop(pid)
+                self._write_data(f, data)
+            except KeyError:
+                raise ValueError(f"No known repository for process {pid}.")
+        _log.info("Unregistered %s from process %d.", repo, pid)
+        return repo
+
+    def get_owner(self, repo: str) -> int:
+        """Check the process responsible for a repo.
+
+        Parameters
+        ----------
+        repo : `str`
+            The repo to look up.
+
+        Returns
+        ------
+        pid : `int`
+            The process associated with the repo.
+
+        Raises
+        ------
+        ValueError
+            Raised if ``repo`` is unknown to the tracker.
+        """
+        with self._open_exclusive(self._BACKEND_FILE, mode="r+") as f:
+            data = self._read_data(f)
+
+        try:
+            return self._reverse_lookup(data, repo)
+        except KeyError:
+            raise ValueError(f"Repository {repo} is not owned by any process.")

--- a/tests/test_repo_tracker.py
+++ b/tests/test_repo_tracker.py
@@ -1,0 +1,125 @@
+# This file is part of prompt_processing.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import functools
+import os.path
+import tempfile
+import unittest
+
+from activator.repo_tracker import LocalRepoTracker
+
+
+def patched_tracker(method):
+    @functools.wraps(method)
+    def wrapper(self, *args, **kwargs):
+        # Need separate tracker if running tests in same process
+        # Need separate location if running tests in parallel
+        with tempfile.TemporaryDirectory() as reg_dir, \
+            unittest.mock.patch("activator.repo_tracker.LocalRepoTracker._BACKEND_FILE",
+                                os.path.join(reg_dir, "test.csv")):
+            tracker = LocalRepoTracker()
+            with unittest.mock.patch("activator.repo_tracker.LocalRepoTracker.get",
+                                     return_value=tracker):
+                tracker.init_tracker()
+                try:
+                    return method(self, *args, **kwargs)
+                finally:
+                    tracker.cleanup_tracker()
+    return wrapper
+
+
+class LocalRepoTrackerTest(unittest.TestCase):
+    """Test the LocalRepoTracker class's functionality.
+
+    The class has a hardcoded location for the data, and no built-in way to
+    clean it up (it is designed to have pod lifetime). As a workaround, use
+    `patched_tracker` to decorate all tests.
+    """
+
+    @patched_tracker
+    def test_singleton(self):
+        self.assertIs(LocalRepoTracker.get(), LocalRepoTracker.get())
+
+    @patched_tracker
+    def test_register_pop(self):
+        test_data = {42: "/foo/bar/repo",
+                     101: "/baz/bak/butler.yaml",
+                     }
+        testbed = LocalRepoTracker.get()
+
+        testbed.register(101, test_data[101])
+        testbed.register(42, test_data[42])
+        for pid, repo in test_data.items():
+            self.assertEqual(testbed.get_owner(repo), pid)
+        for pid, repo in test_data.items():
+            self.assertEqual(testbed.pop(pid), repo)
+            with self.assertRaises(ValueError):
+                testbed.get_owner(repo)
+
+    @patched_tracker
+    def test_register_twice(self):
+        testbed = LocalRepoTracker.get()
+
+        testbed.register(42, "/foo/bar/repo")
+        self.assertEqual(testbed.get_owner("/foo/bar/repo"), 42)
+        with self.assertRaises(ValueError):
+            testbed.get_owner("/baz/bak/butler.yaml")
+        with self.assertRaises(ValueError):
+            testbed.register(42, "/baz/bak/butler.yaml")  # duplicate pid
+        with self.assertRaises(ValueError):
+            testbed.register(101, "/foo/bar/repo")  # duplicate repo
+        testbed.register(101, "/baz/bak/butler.yaml")
+
+    @patched_tracker
+    def test_empty_pop(self):
+        testbed = LocalRepoTracker.get()
+
+        with self.assertRaises(ValueError):
+            testbed.pop(42)
+        with self.assertRaises(ValueError):
+            testbed.get_owner("/foo/bar/repo")
+
+    @patched_tracker
+    def test_double_pop(self):
+        testbed = LocalRepoTracker.get()
+
+        testbed.register(42, "/foo/bar/repo")
+        self.assertEqual(testbed.pop(42), "/foo/bar/repo")
+        with self.assertRaises(ValueError):
+            testbed.pop(42)
+
+    @patched_tracker
+    def test_pop_register(self):
+        testbed = LocalRepoTracker.get()
+
+        testbed.register(42, "/foo/bar/repo")
+        self.assertEqual(testbed.pop(42), "/foo/bar/repo")
+        testbed.register(42, "/baz/bak/butler.yaml")
+        self.assertEqual(testbed.pop(42), "/baz/bak/butler.yaml")
+
+    @patched_tracker
+    def test_get_owner_change(self):
+        testbed = LocalRepoTracker.get()
+
+        testbed.register(42, "/foo/bar/repo")
+        self.assertEqual(testbed.pop(42), "/foo/bar/repo")
+        testbed.register(101, "/foo/bar/repo")
+        self.assertEqual(testbed.get_owner("/foo/bar/repo"), 101)


### PR DESCRIPTION
This PR refactors the activator to be importable without side effects, as well as to separate application logic from Flask and HTTP-specific logic (this may make it possible to abandon Flask, or to provide alternatives, in the future). It then adds a more sophisticated system for local repo management that allows multiple repos to coexist on the same pod, as well as a configuration flag to request multiple workers from Gunicorn.