### PR TITLE
DM-45447: Update Prompt Processing base build for rubin-env 9

### DIFF
--- a/.github/workflows/build-base.yml
+++ b/.github/workflows/build-base.yml
@@ -71,7 +71,7 @@ jobs:
           fi
           echo "Docker tag = $(< lsst.docker.tag)"
           echo "Stack tag = $(< stack.tag)"
-          docker run "$PIPE_CONTAINER":"$(< lsst.docker.tag)" bash -c "cat stack/miniconda*/ups_db/global.tags" > eups.tag || echo "Unknown" > eups.tag
+          docker run "$PIPE_CONTAINER":"$(< lsst.docker.tag)" bash -c "cat conda/envs/lsst-scipipe-*/share/eups/ups_db/global.tags" > eups.tag || docker run "$PIPE_CONTAINER":"$(< lsst.docker.tag)" bash -c "cat stack/miniconda*/ups_db/global.tags" > eups.tag || echo "Unknown" > eups.tag
           echo "Eups tag = $(< eups.tag)"
       - name: Build image
         # Context-free build

--- a/.github/workflows/build-service.yml
+++ b/.github/workflows/build-service.yml
@@ -96,7 +96,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Determine eups tag
         run: |
-          docker run ghcr.io/${{ github.repository_owner }}/prompt-base:"$BASE_TAG" bash -c "cat stack/miniconda*/ups_db/global.tags" > eups.tag || echo "Unknown" > eups.tag
+          docker run ghcr.io/${{ github.repository_owner }}/prompt-base:"$BASE_TAG" bash -c "cat conda/envs/lsst-scipipe-*/share/eups/ups_db/global.tags" > eups.tag || docker run ghcr.io/${{ github.repository_owner }}/prompt-base:"$BASE_TAG" bash -c "cat stack/miniconda*/ups_db/global.tags" > eups.tag || echo "Unknown" > eups.tag
           echo "Eups tag = $(< eups.tag)"
       - name: Build image
         run: |

--- a/tests/test_raw.py
+++ b/tests/test_raw.py
@@ -82,7 +82,10 @@ class RawBase:
 
 @unittest.skipIf(not boto3, "Warning: boto3 AWS SDK not found!")
 class LsstBase(RawBase):
-    mock_s3 = mock_s3()
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.mock_s3 = mock_s3()
 
     def setUp(self):
         self.mock_s3.start()

--- a/tests/test_raw.py
+++ b/tests/test_raw.py
@@ -40,7 +40,10 @@ from activator.visit import FannedOutVisit
 
 try:
     import boto3
-    from moto import mock_s3
+    try:
+        from moto import mock_aws
+    except ImportError:
+        from moto import mock_s3 as mock_aws  # Backwards-compatible with moto 4
 except ImportError:
     boto3 = None
 
@@ -85,10 +88,10 @@ class LsstBase(RawBase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.mock_s3 = mock_s3()
+        cls.mock_aws = mock_aws()
 
     def setUp(self):
-        self.mock_s3.start()
+        self.mock_aws.start()
         s3 = boto3.resource("s3")
         self.bucket = "test-bucket-test"
         s3.create_bucket(Bucket=self.bucket)
@@ -100,7 +103,7 @@ class LsstBase(RawBase):
         super().setUp()
 
     def tearDown(self):
-        self.mock_s3.stop()
+        self.mock_aws.stop()
         super().tearDown()
 
     def test_snap_matching(self):

--- a/tests/test_tester_utils.py
+++ b/tests/test_tester_utils.py
@@ -22,10 +22,6 @@
 import tempfile
 import unittest
 
-import boto3
-import botocore
-from moto import mock_s3
-
 import lsst.daf.butler.tests as butler_tests
 import lsst.meas.base
 from lsst.obs.subaru import HyperSuprimeCam
@@ -39,12 +35,24 @@ from tester.utils import (
     increment_group,
 )
 
+try:
+    import boto3
+    import botocore
+    from moto import mock_s3
+except ImportError:
+    boto3 = None
 
+
+@unittest.skipIf(not boto3, "Warning: boto3 AWS SDK not found!")
 class TesterUtilsTest(unittest.TestCase):
     """Test components in tester.
     """
-    mock_s3 = mock_s3()
     bucket_name = "testBucketName"
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.mock_s3 = mock_s3()
 
     def setUp(self):
         self.mock_s3.start()

--- a/tests/test_tester_utils.py
+++ b/tests/test_tester_utils.py
@@ -38,7 +38,10 @@ from tester.utils import (
 try:
     import boto3
     import botocore
-    from moto import mock_s3
+    try:
+        from moto import mock_aws
+    except ImportError:
+        from moto import mock_s3 as mock_aws  # Backwards-compatible with moto 4
 except ImportError:
     boto3 = None
 
@@ -52,10 +55,10 @@ class TesterUtilsTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.mock_s3 = mock_s3()
+        cls.mock_aws = mock_aws()
 
     def setUp(self):
-        self.mock_s3.start()
+        self.mock_aws.start()
         s3 = boto3.resource("s3")
         s3.create_bucket(Bucket=self.bucket_name)
 
@@ -92,7 +95,7 @@ class TesterUtilsTest(unittest.TestCase):
                 bucket.delete()
         finally:
             # Stop the S3 mock.
-            self.mock_s3.stop()
+            self.mock_aws.stop()
 
     def test_get_last_group(self):
         s3 = boto3.resource("s3")


### PR DESCRIPTION
This PR updates our build system to support rubin-env 9 Pipelines containers. It is backwards-compatible with rubin-env 8.