### PR TITLE
DM-43418: Divide AP pipeline into preload and prompt subsets

### DIFF
--- a/pipelines/HSC/ApPipe.yaml
+++ b/pipelines/HSC/ApPipe.yaml
@@ -2,6 +2,8 @@ description: End to end Alert Production pipeline specialized for HSC-RC2
 
 imports:
   - location: $AP_PIPE_DIR/pipelines/HSC/ApPipe.yaml
+    include:
+      - prompt
 parameters:
   # Use dataset's specific templates
   coaddName: goodSeeing

--- a/pipelines/HSC/Preprocessing.yaml
+++ b/pipelines/HSC/Preprocessing.yaml
@@ -1,0 +1,9 @@
+description: Preprocessing pipeline specialized for HSC-RC2
+
+imports:
+  - location: $AP_PIPE_DIR/pipelines/HSC/ApPipe.yaml
+    include:
+      - preload
+parameters:
+  # Use dataset's specific templates
+  coaddName: goodSeeing

--- a/pipelines/LATISS/ApPipe-noForced.yaml
+++ b/pipelines/LATISS/ApPipe-noForced.yaml
@@ -7,11 +7,9 @@ description: >-
 # will not be synced to the ap_pipe package.
 imports:
   - location: $PROMPT_PROCESSING_DIR/pipelines/LATISS/ApPipe.yaml
+    include:
+      - prompt
 tasks:
-  loadDiaCatalogs:
-    class: lsst.ap.association.LoadDiaCatalogsTask
-    config:
-      doLoadForcedSources: false  # see DM-43394
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:

--- a/pipelines/LATISS/ApPipe.yaml
+++ b/pipelines/LATISS/ApPipe.yaml
@@ -6,6 +6,8 @@ description: Alert Production pipeline specialized for LATISS
 # release schedule.
 imports:
   - location: $AP_PIPE_DIR/pipelines/LATISS/ApPipe.yaml
+    include:
+      - prompt
 tasks:
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask

--- a/pipelines/LATISS/Preprocessing-noForced.yaml
+++ b/pipelines/LATISS/Preprocessing-noForced.yaml
@@ -1,0 +1,14 @@
+description: Preprocessing pipeline specialized for LATISS, with forced source loading turned off
+
+# This file serves as an "emergency shutdown" for a known issue in the DIA
+# processing task. It is not intended for general use, and unlike ApPipe proper
+# will not be synced to the ap_pipe package.
+imports:
+  - location: $AP_PIPE_DIR/pipelines/LATISS/ApPipe.yaml
+    include:
+      - preload
+tasks:
+  loadDiaCatalogs:
+    class: lsst.ap.association.LoadDiaCatalogsTask
+    config:
+      doLoadForcedSources: false  # see DM-43394

--- a/pipelines/LATISS/Preprocessing.yaml
+++ b/pipelines/LATISS/Preprocessing.yaml
@@ -1,0 +1,6 @@
+description: Preprocessing pipeline specialized for LATISS
+
+imports:
+  - location: $AP_PIPE_DIR/pipelines/LATISS/ApPipe.yaml
+    include:
+      - preload

--- a/pipelines/LSSTComCamSim/ApPipe-noForced.yaml
+++ b/pipelines/LSSTComCamSim/ApPipe-noForced.yaml
@@ -7,11 +7,9 @@ description: >-
 # will not be synced to the ap_pipe package.
 imports:
   - location: $PROMPT_PROCESSING_DIR/pipelines/LSSTComCamSim/ApPipe.yaml
+    include:
+      - prompt
 tasks:
-  loadDiaCatalogs:
-    class: lsst.ap.association.LoadDiaCatalogsTask
-    config:
-      doLoadForcedSources: false  # see DM-43394
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:

--- a/pipelines/LSSTComCamSim/ApPipe.yaml
+++ b/pipelines/LSSTComCamSim/ApPipe.yaml
@@ -6,6 +6,8 @@ description: Alert Production pipeline specialized for LSSTComCamSim
 # release schedule.
 imports:
   - location: $AP_PIPE_DIR/pipelines/LSSTComCamSim/ApPipe.yaml
+    include:
+      - prompt
 tasks:
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask

--- a/pipelines/LSSTComCamSim/Preprocessing-noForced.yaml
+++ b/pipelines/LSSTComCamSim/Preprocessing-noForced.yaml
@@ -1,0 +1,14 @@
+description: Preprocessing pipeline specialized for LSSTComCamSim with forced source loading turned off
+
+# This file serves as an "emergency shutdown" for a known issue in the DIA
+# processing task. It is not intended for general use, and unlike ApPipe proper
+# will not be synced to the ap_pipe package.
+imports:
+  - location: $AP_PIPE_DIR/pipelines/LSSTComCamSim/ApPipe.yaml
+    include:
+      - preload
+tasks:
+  loadDiaCatalogs:
+    class: lsst.ap.association.LoadDiaCatalogsTask
+    config:
+      doLoadForcedSources: false  # see DM-43394

--- a/pipelines/LSSTComCamSim/Preprocessing.yaml
+++ b/pipelines/LSSTComCamSim/Preprocessing.yaml
@@ -1,0 +1,6 @@
+description: Preprocessing pipeline specialized for LSSTComCamSim
+
+imports:
+  - location: $AP_PIPE_DIR/pipelines/LSSTComCamSim/ApPipe.yaml
+    include:
+      - preload

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -22,6 +22,7 @@
 __all__ = ["next_visit_handler"]
 
 import collections.abc
+import contextlib
 import json
 import logging
 import os
@@ -300,160 +301,162 @@ def next_visit_handler() -> tuple[str, int]:
         The HTTP response status code to return to the client.
     """
     _log.info(f"Starting next_visit_handler for {request}.")
-    consumer.subscribe([bucket_topic])
-    _log.debug(f"Created subscription to '{bucket_topic}'")
-    # Try to get a message right away to minimize race conditions
-    startup_response = consumer.consume(num_messages=1, timeout=0.001)
+    with contextlib.ExitStack():
+        consumer.subscribe([bucket_topic])
+        _log.debug(f"Created subscription to '{bucket_topic}'")
+        # Try to get a message right away to minimize race conditions
+        startup_response = consumer.consume(num_messages=1, timeout=0.001)
 
-    try:
         try:
-            expected_visit = parse_next_visit(request)
-        except ValueError as msg:
-            _log.warn(f"error: '{msg}'")
-            return f"Bad Request: {msg}", 400
-        assert expected_visit.instrument == instrument_name, \
-            f"Expected {instrument_name}, received {expected_visit.instrument}."
-        if not main_pipelines.get_pipeline_files(expected_visit):
-            _log.info(f"No pipeline configured for {expected_visit}, skipping.")
-            return "No pipeline configured for the received visit.", 422
-
-        log_factory = logging.getLogRecordFactory()
-        with log_factory.add_context(group=expected_visit.groupId,
-                                     survey=expected_visit.survey,
-                                     detector=expected_visit.detector,
-                                     ):
             try:
-                expid_set = set()
+                expected_visit = parse_next_visit(request)
+            except ValueError as msg:
+                _log.warn(f"error: '{msg}'")
+                return f"Bad Request: {msg}", 400
+            assert expected_visit.instrument == instrument_name, \
+                f"Expected {instrument_name}, received {expected_visit.instrument}."
+            if not main_pipelines.get_pipeline_files(expected_visit):
+                _log.info(f"No pipeline configured for {expected_visit}, skipping.")
+                return "No pipeline configured for the received visit.", 422
 
-                # Create a fresh MiddlewareInterface object to avoid accidental
-                # "cross-talk" between different visits.
-                mwi = MiddlewareInterface(central_butler,
-                                          image_bucket,
-                                          expected_visit,
-                                          pre_pipelines,
-                                          main_pipelines,
-                                          skymap,
-                                          local_repo.name,
-                                          local_cache)
-                # Copy calibrations for this detector/visit
-                mwi.prep_butler()
+            log_factory = logging.getLogRecordFactory()
+            with log_factory.add_context(group=expected_visit.groupId,
+                                         survey=expected_visit.survey,
+                                         detector=expected_visit.detector,
+                                         ):
+                try:
+                    expid_set = set()
 
-                # expected_visit.nimages == 0 means "not known in advance"; keep listening until timeout
-                expected_snaps = expected_visit.nimages if expected_visit.nimages else 100
-                # Heuristic: take the upcoming script's duration and multiply by 2 to
-                # include the currently executing script, then add time to transfer
-                # the last image.
-                timeout = expected_visit.duration * 2 + image_timeout
-                # Check to see if any snaps have already arrived
-                for snap in range(expected_snaps):
-                    oid = check_for_snap(
-                        storage_client,
-                        image_bucket,
-                        raw_microservice,
-                        expected_visit.instrument,
-                        expected_visit.groupId,
-                        snap,
-                        expected_visit.detector,
-                    )
+                    # Create a fresh MiddlewareInterface object to avoid accidental
+                    # "cross-talk" between different visits.
+                    mwi = MiddlewareInterface(central_butler,
+                                              image_bucket,
+                                              expected_visit,
+                                              pre_pipelines,
+                                              main_pipelines,
+                                              skymap,
+                                              local_repo.name,
+                                              local_cache)
+                    # Copy calibrations for this detector/visit
+                    mwi.prep_butler()
+
+                    # expected_visit.nimages == 0 means "not known in advance"; keep listening until timeout
+                    expected_snaps = expected_visit.nimages if expected_visit.nimages else 100
+                    # Heuristic: take the upcoming script's duration and multiply by 2 to
+                    # include the currently executing script, then add time to transfer
+                    # the last image.
+                    timeout = expected_visit.duration * 2 + image_timeout
+                    # Check to see if any snaps have already arrived
+                    for snap in range(expected_snaps):
+                        oid = check_for_snap(
+                            storage_client,
+                            image_bucket,
+                            raw_microservice,
+                            expected_visit.instrument,
+                            expected_visit.groupId,
+                            snap,
+                            expected_visit.detector,
+                        )
                     if oid:
                         _log.debug("Found object %s already present", oid)
                         exp_id = mwi.ingest_image(oid)
                         expid_set.add(exp_id)
 
-                _log.debug("Waiting for snaps...")
-                start = time.time()
-                while len(expid_set) < expected_snaps and time.time() - start < timeout:
-                    if startup_response:
-                        response = startup_response
-                    else:
-                        time_remaining = max(0.0, timeout - (time.time() - start))
-                        response = consumer.consume(num_messages=1, timeout=time_remaining + 1.0)
-                    end = time.time()
-                    messages = _filter_messages(response)
-                    response = []
-                    if len(messages) == 0 and end - start < timeout and not startup_response:
-                        _log.debug(f"Empty consume after {end - start}s.")
-                        continue
-                    startup_response = []
+                    _log.debug("Waiting for snaps...")
+                    start = time.time()
+                    while len(expid_set) < expected_snaps and time.time() - start < timeout:
+                        if startup_response:
+                            response = startup_response
+                        else:
+                            time_remaining = max(0.0, timeout - (time.time() - start))
+                            response = consumer.consume(num_messages=1, timeout=time_remaining + 1.0)
+                        end = time.time()
+                        messages = _filter_messages(response)
+                        response = []
+                        if len(messages) == 0 and end - start < timeout and not startup_response:
+                            _log.debug(f"Empty consume after {end - start}s.")
+                            continue
+                        startup_response = []
 
-                    # Not all notifications are for this group/detector
-                    for received in messages:
-                        for oid in _parse_bucket_notifications(received.value()):
-                            try:
-                                if is_path_consistent(oid, expected_visit):
-                                    _log.debug("Received %r", oid)
-                                    group_id = get_group_id_from_oid(oid)
-                                    if group_id == expected_visit.groupId:
-                                        # Ingest the snap
-                                        exp_id = mwi.ingest_image(oid)
-                                        expid_set.add(exp_id)
-                            except ValueError:
-                                _log.error(f"Failed to match object id '{oid}'")
-                        # Commits are per-group, so this can't interfere with other
-                        # workers. This may wipe messages associated with a next_visit
-                        # that will later be assigned to this worker, but those cases
-                        # should be caught by the "already arrived" check.
-                        consumer.commit(message=received)
-                if len(expid_set) < expected_snaps:
-                    _log.warning(f"Timed out waiting for image after receiving exposures {expid_set}.")
-            except GracefulShutdownInterrupt as e:
-                _log.exception("Processing interrupted before pipeline execution")
-                # Do not export, to leave room for the next attempt
-                # Service unavailable is not quite right, but no better standard response
-                raise ServiceUnavailable(f"The server aborted processing, but it can be retried: {e}",
-                                         retry_after=10) from None
+                        # Not all notifications are for this group/detector
+                        for received in messages:
+                            for oid in _parse_bucket_notifications(received.value()):
+                                try:
+                                    if is_path_consistent(oid, expected_visit):
+                                        _log.debug("Received %r", oid)
+                                        group_id = get_group_id_from_oid(oid)
+                                        if group_id == expected_visit.groupId:
+                                            # Ingest the snap
+                                            exp_id = mwi.ingest_image(oid)
+                                            expid_set.add(exp_id)
+                                except ValueError:
+                                    _log.error(f"Failed to match object id '{oid}'")
+                            # Commits are per-group, so this can't interfere with other
+                            # workers. This may wipe messages associated with a next_visit
+                            # that will later be assigned to this worker, but those cases
+                            # should be caught by the "already arrived" check.
+                            consumer.commit(message=received)
+                    if len(expid_set) < expected_snaps:
+                        _log.warning(f"Timed out waiting for image after receiving exposures {expid_set}.")
+                except GracefulShutdownInterrupt as e:
+                    _log.exception("Processing interrupted before pipeline execution")
+                    # Do not export, to leave room for the next attempt
+                    # Service unavailable is not quite right, but no better standard response
+                    raise ServiceUnavailable(f"The server aborted processing, but it can be retried: {e}",
+                                             retry_after=10) from None
 
-            if expid_set:
-                with log_factory.add_context(exposures=expid_set):
-                    # Got at least some snaps; run the pipeline.
-                    # If this is only a partial set, the processed results may still be
-                    # useful for quality purposes.
-                    # If nimages == 0, any positive number of snaps is OK.
-                    if len(expid_set) < expected_visit.nimages:
-                        _log.warning(f"Processing {len(expid_set)} snaps, expected {expected_visit.nimages}.")
-                    _log.info("Running pipeline...")
-                    try:
-                        mwi.run_pipeline(expid_set)
+                if expid_set:
+                    with log_factory.add_context(exposures=expid_set):
+                        # Got at least some snaps; run the pipeline.
+                        # If this is only a partial set, the processed results may still be
+                        # useful for quality purposes.
+                        # If nimages == 0, any positive number of snaps is OK.
+                        if len(expid_set) < expected_visit.nimages:
+                            _log.warning(f"Processing {len(expid_set)} snaps, "
+                                         f"expected {expected_visit.nimages}.")
+                        _log.info("Running pipeline...")
                         try:
-                            # TODO: broadcast alerts here
-                            mwi.export_outputs(expid_set)
+                            mwi.run_pipeline(expid_set)
+                            try:
+                                # TODO: broadcast alerts here
+                                mwi.export_outputs(expid_set)
+                            except Exception as e:
+                                raise NonRetriableError("APDB and possibly alerts or central repo modified") \
+                                    from e
+                        except RetriableError as e:
+                            error = e.nested if e.nested else e
+                            _log.error("Processing failed but can be retried: ", exc_info=error)
+                            # Do not export, to leave room for the next attempt
+                            # Service unavailable is not quite right, but no better standard response
+                            raise ServiceUnavailable(f"A temporary error occurred during processing: {error}",
+                                                     retry_after=10) from None
+                        except NonRetriableError as e:
+                            error = e.nested if e.nested else e
+                            _log.error("Processing failed: ", exc_info=error)
+                            _try_export(mwi, expid_set, _log)
+                            return f"An error occurred during processing: {error}.\nThe system's state has " \
+                                   "permanently changed, so this request should **NOT** be retried.", 500
                         except Exception as e:
-                            raise NonRetriableError("APDB and possibly alerts or central repo modified") \
-                                from e
-                    except RetriableError as e:
-                        error = e.nested if e.nested else e
-                        _log.error("Processing failed but can be retried: ", exc_info=error)
-                        # Do not export, to leave room for the next attempt
-                        # Service unavailable is not quite right, but no better standard response
-                        raise ServiceUnavailable(f"A temporary error occurred during processing: {error}",
-                                                 retry_after=10) from None
-                    except NonRetriableError as e:
-                        error = e.nested if e.nested else e
-                        _log.error("Processing failed: ", exc_info=error)
-                        _try_export(mwi, expid_set, _log)
-                        return f"An error occurred during processing: {error}.\nThe system's state has " \
-                               "permanently changed, so this request should **NOT** be retried.", 500
-                    except Exception as e:
-                        _log.error("Processing failed: ", exc_info=e)
-                        _try_export(mwi, expid_set, _log)
-                        return f"An error occurred during processing: {e}.", 500
-                    finally:
-                        # TODO: run_pipeline requires a clean run until DM-38041.
-                        mwi.clean_local_repo(expid_set)
-                    return "Pipeline executed", 200
-            else:
-                _log.error("Timed out waiting for images.")
-                return "Timed out waiting for images", 500
-    except GracefulShutdownInterrupt:
-        # Safety net to minimize chance of interrupt propagating out of the worker.
-        # Ideally, this would be a Flask.errorhandler, but Flask ignores BaseExceptions.
-        _log.error("Service interrupted. Shutting down *without* syncing to the central repo.")
-        return "The worker was interrupted before it could complete the request. " \
-               "Retrying the request may not be safe.", 500
-    finally:
-        consumer.unsubscribe()
-        # Want to know when the handler exited for any reason.
-        _log.info("next_visit handling completed.")
+                            _log.error("Processing failed: ", exc_info=e)
+                            _try_export(mwi, expid_set, _log)
+                            return f"An error occurred during processing: {e}.", 500
+                        finally:
+                            # TODO: run_pipeline requires a clean run until DM-38041.
+                            mwi.clean_local_repo(expid_set)
+                        return "Pipeline executed", 200
+                else:
+                    _log.error("Timed out waiting for images.")
+                    return "Timed out waiting for images", 500
+        except GracefulShutdownInterrupt:
+            # Safety net to minimize chance of interrupt propagating out of the worker.
+            # Ideally, this would be a Flask.errorhandler, but Flask ignores BaseExceptions.
+            _log.error("Service interrupted. Shutting down *without* syncing to the central repo.")
+            return "The worker was interrupted before it could complete the request. " \
+                   "Retrying the request may not be safe.", 500
+        finally:
+            consumer.unsubscribe()
+            # Want to know when the handler exited for any reason.
+            _log.info("next_visit handling completed.")
 
 
 @app.errorhandler(500)

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -1678,14 +1678,15 @@ class MiddlewareInterface:
         """
         with lsst.utils.timer.time_this(_log, msg="clean_local_repo", level=logging.DEBUG):
             self.butler.registry.refresh()
-            raws = self.butler.registry.queryDatasets(
-                'raw',
-                collections=self.instrument.makeDefaultRawIngestRunName(),
-                where=f"exposure in ({', '.join(str(x) for x in exposure_ids)})",
-                instrument=self.visit.instrument,
-                detector=self.visit.detector,
-            )
-            self.butler.pruneDatasets(raws, disassociate=True, unstore=True, purge=True)
+            if exposure_ids:
+                raws = self.butler.registry.queryDatasets(
+                    'raw',
+                    collections=self.instrument.makeDefaultRawIngestRunName(),
+                    where=f"exposure in ({', '.join(str(x) for x in exposure_ids)})",
+                    instrument=self.visit.instrument,
+                    detector=self.visit.detector,
+                )
+                self.butler.pruneDatasets(raws, disassociate=True, unstore=True, purge=True)
             # Outputs are all in their own runs, so just drop them.
             preload_run = self._get_preload_run(self._day_obs)
             _remove_run_completely(self.butler, preload_run)


### PR DESCRIPTION
This PR splits the pipeline files into separate pipelines, corresponding to the `prompt` and `preload` subsets from lsst/ap_pipe#191.

This pipeline needs to be tested after a daily is built with lsst/ap_pipe#191.