### PR TITLE
DM-46520: Raise on AnnotatedPartialOutputsError in Prompt Processing

### DIFF
--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -1194,6 +1194,7 @@ class MiddlewareInterface:
         quantum_executor = SingleQuantumExecutor(
             butler,
             factory,
+            assumeNoExistingOutputs=True,  # Outputs cleared out on success *or* failure
             raise_on_partial_outputs=True,  # Only way to detect that partial outputs happened
         )
         graph_executor = MPGraphExecutor(

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -1194,6 +1194,7 @@ class MiddlewareInterface:
         quantum_executor = SingleQuantumExecutor(
             butler,
             factory,
+            raise_on_partial_outputs=True,  # Only way to detect that partial outputs happened
         )
         graph_executor = MPGraphExecutor(
             # TODO: re-enable parallel execution once we can log as desired with CliLog or a successor


### PR DESCRIPTION
This PR adds behavior flags to `SingleQuantumExecutor` to be less tolerant of pipeline failures.