### PR TITLE
DM-46603: Reset expired visit ID calculation for Prompt Processing HSC tests

### DIFF
--- a/python/tester/utils.py
+++ b/python/tester/utils.py
@@ -146,10 +146,10 @@ def make_compressed_date(date):
 
     Notes
     -----
-    The current implementation gives 4-digit results until September 2024.
+    The current implementation gives 4-digit results until September 2025.
     If this generator is still needed after that, it will need to be tweaked.
     """
-    year = int(date[:4]) - 2023            # Always 1 digit, 0-1
+    year = int(date[:4]) - 2024            # Always 1 digit, 0-1
     night_id = int(date[-4:])              # Always 4 digits up to 1231
     compressed = year*1200 + night_id      # Always 4 digits
     limit = max_exposure["HSC"] // 10_000

--- a/tests/test_tester_utils.py
+++ b/tests/test_tester_utils.py
@@ -114,11 +114,11 @@ class TesterUtilsTest(unittest.TestCase):
         s3 = boto3.resource("s3")
         bucket = s3.Bucket(self.bucket_name)
 
-        last_group = get_last_group(bucket, "HSC", "20231102")
+        last_group = get_last_group(bucket, "HSC", "20241102")
         self.assertEqual(last_group, "11020002")
 
         # Test the case of no match
-        last_group = get_last_group(bucket, "HSC", "20240101")
+        last_group = get_last_group(bucket, "HSC", "20250101")
         self.assertEqual(last_group, "13010000")
 
     def test_exposure_id_hsc(self):
@@ -151,10 +151,10 @@ class TesterUtilsTest(unittest.TestCase):
         s3 = boto3.resource("s3")
         bucket = s3.Bucket(self.bucket_name)
 
-        group = get_last_group(bucket, "HSC", "20240930")
+        group = get_last_group(bucket, "HSC", "20250930")
         self.assertEqual(group, "21300000")
         with self.assertRaises(RuntimeError):
-            get_last_group(bucket, "HSC", "20241001")
+            get_last_group(bucket, "HSC", "20251001")
 
 
 class TesterGoupIdTest(unittest.TestCase):


### PR DESCRIPTION
This PR redefines the algorithm for generating mock HSC visit IDs so that we can keep running HSC tests into 2025.