### PR TITLE
DM-47067: Document config overrides in PP pipelines

### DIFF
--- a/pipelines/LATISS/ApPipe.yaml
+++ b/pipelines/LATISS/ApPipe.yaml
@@ -13,5 +13,4 @@ tasks:
     class: lsst.ap.association.DiaPipelineTask
     config:
       # Alert distribution only runnable in PP environment.
-      doPackageAlerts: True
       alertPackager.doProduceAlerts: True

--- a/pipelines/LATISS/ApPipe.yaml
+++ b/pipelines/LATISS/ApPipe.yaml
@@ -12,5 +12,6 @@ tasks:
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:
+      # Alert distribution only runnable in PP environment.
       doPackageAlerts: True
       alertPackager.doProduceAlerts: True

--- a/pipelines/LSSTComCam/ApPipe.yaml
+++ b/pipelines/LSSTComCam/ApPipe.yaml
@@ -13,5 +13,4 @@ tasks:
     class: lsst.ap.association.DiaPipelineTask
     config:
       # Alert distribution only runnable in PP environment.
-      doPackageAlerts: True
       alertPackager.doProduceAlerts: True

--- a/pipelines/LSSTComCam/ApPipe.yaml
+++ b/pipelines/LSSTComCam/ApPipe.yaml
@@ -12,5 +12,6 @@ tasks:
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:
+      # Alert distribution only runnable in PP environment.
       doPackageAlerts: True
       alertPackager.doProduceAlerts: True

--- a/pipelines/LSSTComCamSim/ApPipe.yaml
+++ b/pipelines/LSSTComCamSim/ApPipe.yaml
@@ -13,5 +13,4 @@ tasks:
     class: lsst.ap.association.DiaPipelineTask
     config:
       # Alert distribution only runnable in PP environment.
-      doPackageAlerts: True
       alertPackager.doProduceAlerts: True

--- a/pipelines/LSSTComCamSim/ApPipe.yaml
+++ b/pipelines/LSSTComCamSim/ApPipe.yaml
@@ -12,5 +12,6 @@ tasks:
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:
+      # Alert distribution only runnable in PP environment.
       doPackageAlerts: True
       alertPackager.doProduceAlerts: True


### PR DESCRIPTION
This PR adds an explanation for why we only set `doProduceAlerts` in PP, and moves alert generation into the main `ap_pipe` (lsst/ap_pipe#205).