### PR TITLE
DM-47387: Prompt Processing can't handle blank filters in nextVisit message

### DIFF
--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -71,6 +71,8 @@ base_keep_limit = int(os.environ.get("LOCAL_REPO_CACHE_SIZE", 3))-1
 # Multipliers to base_keep_limit for refcats and templates.
 refcat_factor = int(os.environ.get("REFCATS_PER_IMAGE", 4))
 template_factor = int(os.environ.get("PATCHES_PER_IMAGE", 4))
+# Minimum number of datasets to keep for filter-dependent datasets.
+filter_floor = int(os.environ.get("FILTERS_WITH_CALIBS", 20))
 # VALIDITY-HACK: local-only calib collections break if calibs are not requested
 # in chronological order. Turn off for large development runs.
 cache_calibs = bool(int(os.environ.get("DEBUG_CACHE_CALIBS", '1')))
@@ -202,8 +204,8 @@ def make_local_cache():
         base_keep_limit,
         cache_sizes={
             # TODO: find an API that doesn't require explicit enumeration
-            "goodSeeingCoadd": template_factor * base_keep_limit,
-            "deepCoadd": template_factor * base_keep_limit,
+            "goodSeeingCoadd": template_factor * max(base_keep_limit, filter_floor),
+            "deepCoadd": template_factor * max(base_keep_limit, filter_floor),
             "uw_stars_20240524": refcat_factor * base_keep_limit,
             "uw_stars_20240228": refcat_factor * base_keep_limit,
             "uw_stars_20240130": refcat_factor * base_keep_limit,
@@ -212,6 +214,11 @@ def make_local_cache():
             "gaia_dr2_20200414": refcat_factor * base_keep_limit,
             "atlas_refcat2_20220201": refcat_factor * base_keep_limit,
             "the_monster_20240904": refcat_factor * base_keep_limit,
+            "eo_flat": max(base_keep_limit, filter_floor),
+            "flat": max(base_keep_limit, filter_floor),
+            "flatBootstrap": max(base_keep_limit, filter_floor),
+            "fringe": max(base_keep_limit, filter_floor),
+            "transmission_filter": max(base_keep_limit, filter_floor),
         },
     )
 

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -1248,7 +1248,7 @@ class MiddlewareInterface:
             exec_butler = Butler(butler=self.butler,
                                  collections=[output_run, init_output_run]
                                  + in_collections
-                                 + list(self.butler.collections),
+                                 + list(self.butler.collections.defaults),
                                  run=output_run)
             factory = lsst.ctrl.mpexec.TaskFactory()
             executor = SeparablePipelineExecutor(

--- a/python/activator/visit.py
+++ b/python/activator/visit.py
@@ -67,7 +67,8 @@ class BareVisit:
     rotationSystem: RotSys      # coordinate system of cameraAngle
     cameraAngle: float          # in degrees
     # physical filter(s) name as used in Middleware. It is a combination of filter and
-    # grating joined by a "~". For example, "SDSSi_65mm~empty".
+    # grating joined by a "~". For example, "SDSSi_65mm~empty". May be empty
+    # to indicate no specific filter.
     filters: str
     dome: Dome
     duration: float             # script execution, not exposure

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -193,7 +193,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
             self.assertTrue(
                 butler.getURI("skyMap", skymap=skymap_name, run="foo", predict=True).ospath
                 .startswith(self.central_repo))
-            self.assertEqual(list(butler.collections), [f"{instname}/defaults"])
+            self.assertEqual(list(butler.collections.defaults), [f"{instname}/defaults"])
             self.assertTrue(butler.isWriteable())
 
     def test_make_local_repo(self):
@@ -218,7 +218,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         # Check that the butler instance is properly configured.
         instruments = list(self.interface.butler.registry.queryDimensionRecords("instrument"))
         self.assertEqual(instname, instruments[0].name)
-        self.assertEqual(set(self.interface.butler.collections), {self.umbrella})
+        self.assertEqual(set(self.interface.butler.collections.defaults), {self.umbrella})
 
         # Check that the ingester is properly configured.
         self.assertEqual(self.interface.rawIngestTask.config.failFast, True)


### PR DESCRIPTION
This PR adds some special-case handling for nextVisit messages with empty filters (as is common for engineering data). The cases are handled at a fairly low level (`_export_calibs` and `_export_skymap_and_templates`) because I don't see an obvious way to unify what's essentially a query tweak. This may need to be revisited on #204, which reworks how the preload queries are executed.