### PR TITLE
DM-47388: Prompt Processing logs an error on surveys configured to "ignore"

### DIFF
--- a/python/activator/exception.py
+++ b/python/activator/exception.py
@@ -20,7 +20,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
-__all__ = ["NonRetriableError", "RetriableError", "GracefulShutdownInterrupt", "InvalidVisitError"]
+__all__ = ["NonRetriableError", "RetriableError", "GracefulShutdownInterrupt",
+           "InvalidVisitError", "IgnorableVisit",
+           ]
 
 
 class NonRetriableError(Exception):
@@ -88,6 +90,17 @@ class GracefulShutdownInterrupt(BaseException):
 class InvalidVisitError(ValueError):
     """An exception raised if a visit object has invalid or inappropriate
     fields.
+
+    See Also
+    --------
+    activator.visit.SummitVisit
+    activator.visit.FannedOutVisit
+    """
+
+
+class IgnorableVisit(ValueError):
+    """An exception raised if a visit object has fields that are valid,
+    but that is configured to not be processed.
 
     See Also
     --------


### PR DESCRIPTION
This PR fixes an issue where ignorable nextVisit messages (which are normal and expected) were being logged as errors, distracting from actual system failures.