### PR TITLE
DM-47529: Migrate Prompt Processing PipelinesConfig to YAML

### DIFF
--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -30,6 +30,7 @@ import os
 import sys
 import time
 import signal
+import yaml
 import uuid
 
 import boto3
@@ -75,13 +76,32 @@ kafka_cluster = os.environ["KAFKA_CLUSTER"]
 kafka_group_id = str(uuid.uuid4())
 # The topic on which to listen to updates to image_bucket
 bucket_topic = os.environ.get("BUCKET_TOPIC", "rubin-prompt-processing")
-# The preprocessing pipelines to execute and the conditions in which to choose them.
-pre_pipelines = PipelinesConfig(os.environ["PREPROCESSING_PIPELINES_CONFIG"])
-# The main pipelines to execute and the conditions in which to choose them.
-main_pipelines = PipelinesConfig(os.environ["MAIN_PIPELINES_CONFIG"])
 
 _log = logging.getLogger("lsst." + __name__)
 _log.setLevel(logging.DEBUG)
+
+
+def _config_from_yaml(yaml_string):
+    """Initialize a PipelinesConfig from a YAML-formatted string.
+
+    Parameters
+    ----------
+    yaml_string : `str`
+        A YAML representation of the structured config. See
+        `~activator.config.PipelineConfig` for details.
+
+    Returns
+    -------
+    config : `activator.config.PipelineConfig`
+        The corresponding config object.
+    """
+    return PipelinesConfig(yaml.safe_load(yaml_string))
+
+
+# The preprocessing pipelines to execute and the conditions in which to choose them.
+pre_pipelines = _config_from_yaml(os.environ["PREPROCESSING_PIPELINES_CONFIG"])
+# The main pipelines to execute and the conditions in which to choose them.
+main_pipelines = _config_from_yaml(os.environ["MAIN_PIPELINES_CONFIG"])
 
 
 def find_local_repos(base_path):

--- a/python/activator/config.py
+++ b/python/activator/config.py
@@ -51,13 +51,6 @@ class PipelinesConfig:
         and no two pipelines may share the same name.
         See examples below.
 
-    Notes
-    -----
-    While it is not expected that there will ever be more than one
-    PipelinesConfig instance in a program's lifetime, this class is *not* a
-    singleton and objects must be passed explicitly to the code that
-    needs them.
-
     Examples
     --------
     A single-survey, single-pipeline config:

--- a/python/activator/config.py
+++ b/python/activator/config.py
@@ -45,7 +45,7 @@ class PipelinesConfig:
         A sequence of mappings ("nodes"), each with the following keys:
 
         ``"survey"``
-            The survey that triggers the pipelines (`str`).
+            The survey that triggers the pipelines (`str`, optional).
         ``"pipelines"``
             A list of zero or more pipelines (sequence [`str`] or `None`). Each
             pipeline path may contain environment variables, and the list of
@@ -53,7 +53,8 @@ class PipelinesConfig:
             be run.
 
         Nodes are arranged by precedence, i.e., the first node that matches a
-        visit is used.
+        visit is used. A node containing only ``pipelines`` is unconstrained
+        and matches *any* visit.
 
     Examples
     --------
@@ -112,8 +113,8 @@ class PipelinesConfig:
                     raise ValueError(f"Pipelines spec must be list or None, got {pipelines_value}")
                 self._check_pipelines(self._filenames)
 
-                survey_value = specs.pop('survey')
-                if isinstance(survey_value, str):
+                survey_value = specs.pop('survey', None)
+                if isinstance(survey_value, str) or survey_value is None:
                     self._survey = survey_value
                 else:
                     raise ValueError(f"{survey_value} is not a valid survey name.")
@@ -158,7 +159,9 @@ class PipelinesConfig:
             matches : `bool`
                 `True` if the visit meets all conditions, `False` otherwise.
             """
-            return self._survey == visit.survey
+            if self._survey is not None and self._survey != visit.survey:
+                return False
+            return True
 
         @property
         def pipeline_files(self) -> collections.abc.Sequence[str]:

--- a/python/activator/config.py
+++ b/python/activator/config.py
@@ -170,7 +170,7 @@ class PipelinesConfig:
         if duplicates:
             raise ValueError(f"Pipeline names must be unique, found multiple copies of {duplicates}.")
 
-    def get_pipeline_files(self, visit: FannedOutVisit) -> str:
+    def get_pipeline_files(self, visit: FannedOutVisit) -> list[str]:
         """Identify the pipeline to be run, based on the provided visit.
 
         Parameters

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -58,27 +58,23 @@ class PipelinesConfigTest(unittest.TestCase):
         )
 
     def test_main_survey(self):
-        config = PipelinesConfig('''
-            -
-              survey: TestSurvey
-              pipelines:
-              - ${PROMPT_PROCESSING_DIR}/pipelines/NotACam/ApPipe.yaml''')
+        config = PipelinesConfig([{"survey": "TestSurvey",
+                                   "pipelines": ["${PROMPT_PROCESSING_DIR}/pipelines/NotACam/ApPipe.yaml"],
+                                   }])
         self.assertEqual(
             config.get_pipeline_files(self.visit),
             [os.path.normpath(os.path.join(TESTDIR, "..", "pipelines", "NotACam", "ApPipe.yaml"))]
         )
 
     def test_selection(self):
-        config = PipelinesConfig('''
-            -
-              survey: TestSurvey
-              pipelines: [/etc/pipelines/SingleFrame.yaml]
-            -
-              survey: CameraTest
-              pipelines: ["${AP_PIPE_DIR}/pipelines/Isr.yaml"]
-            -
-              survey: ""
-              pipelines: [Default.yaml]''')
+        config = PipelinesConfig([{"survey": "TestSurvey",
+                                   "pipelines": ["/etc/pipelines/SingleFrame.yaml"],
+                                   },
+                                  {"survey": "CameraTest",
+                                   "pipelines": ["${AP_PIPE_DIR}/pipelines/Isr.yaml"],
+                                   },
+                                  {"survey": "", "pipelines": ["Default.yaml"]},
+                                  ])
         self.assertEqual(
             config.get_pipeline_files(self.visit),
             [os.path.normpath(os.path.join("/etc", "pipelines", "SingleFrame.yaml"))]
@@ -92,85 +88,23 @@ class PipelinesConfigTest(unittest.TestCase):
             ["Default.yaml"]
         )
 
-    def test_singleline(self):
-        config = PipelinesConfig('[{survey: TestSurvey, pipelines: [/etc/pipelines/SingleFrame.yaml]},'
-                                 " {survey: CameraTest, pipelines: ['${AP_PIPE_DIR}/pipelines/Isr.yaml']}"
-                                 ']')
-        self.assertEqual(
-            config.get_pipeline_files(self.visit),
-            [os.path.normpath(os.path.join("/etc", "pipelines", "SingleFrame.yaml"))]
-        )
-        self.assertEqual(
-            config.get_pipeline_files(dataclasses.replace(self.visit, survey="CameraTest")),
-            [os.path.normpath(os.path.join(getPackageDir("ap_pipe"), "pipelines", "Isr.yaml"))]
-        )
-
     def test_fallback(self):
-        config = PipelinesConfig('''
-            -
-              survey: TestSurvey
-              pipelines:
-              - /etc/pipelines/SingleFrame.yaml
-              - ${AP_PIPE_DIR}/pipelines/Isr.yaml''')
+        config = PipelinesConfig([{"survey": "TestSurvey",
+                                   "pipelines": ["/etc/pipelines/SingleFrame.yaml",
+                                                 "${AP_PIPE_DIR}/pipelines/Isr.yaml",
+                                                 ]}])
         self.assertEqual(
             config.get_pipeline_files(self.visit),
             [os.path.normpath(os.path.join("/etc", "pipelines", "SingleFrame.yaml")),
              os.path.normpath(os.path.join(getPackageDir("ap_pipe"), "pipelines", "Isr.yaml"))]
         )
 
-    def test_space(self):
-        config = PipelinesConfig('''
-          -
-            survey: TestSurvey
-            pipelines: [/dir with space/pipelines/SingleFrame.yaml]
-          -
-            survey: Camera Test
-            pipelines:
-            - ${AP_PIPE_DIR}/pipe lines/Isr.yaml''')
-        self.assertEqual(
-            config.get_pipeline_files(self.visit),
-            [os.path.normpath(os.path.join("/dir with space", "pipelines", "SingleFrame.yaml"))]
-        )
-        self.assertEqual(
-            config.get_pipeline_files(dataclasses.replace(self.visit, survey="Camera Test")),
-            [os.path.normpath(os.path.join(getPackageDir("ap_pipe"), "pipe lines", "Isr.yaml"))]
-        )
-
-    def test_extrachars(self):
-        config = PipelinesConfig(r'''
-            -
-              survey: stylish-modern-survey
-              pipelines: [/etc/pipelines/SingleFrame.yaml]
-            -
-              survey: ScriptParams4,6
-              pipelines: ["${AP_PIPE_DIR}/pipelines/Isr.yaml"]
-            -
-              survey: 'slash/and\backslash'
-              pipelines: [Default.yaml]''')
-        self.assertEqual(
-            config.get_pipeline_files(dataclasses.replace(self.visit, survey="stylish-modern-survey")),
-            [os.path.normpath(os.path.join("/etc", "pipelines", "SingleFrame.yaml"))]
-        )
-        self.assertEqual(
-            config.get_pipeline_files(dataclasses.replace(self.visit, survey="ScriptParams4,6")),
-            [os.path.normpath(os.path.join(getPackageDir("ap_pipe"), "pipelines", "Isr.yaml"))]
-        )
-        self.assertEqual(
-            config.get_pipeline_files(dataclasses.replace(self.visit, survey=r"slash/and\backslash")),
-            ["Default.yaml"]
-        )
-
     def test_none(self):
-        config = PipelinesConfig('''
-            -
-              survey: TestSurvey
-              pipelines: [None shall pass/pipelines/SingleFrame.yaml]
-            -
-              survey: Camera Test
-              pipelines: None
-            -
-              survey: CameraTest
-              pipelines: []''')
+        config = PipelinesConfig([{"survey": "TestSurvey",
+                                   "pipelines": ["None shall pass/pipelines/SingleFrame.yaml"]},
+                                  {"survey": "Camera Test", "pipelines": None},
+                                  {"survey": "CameraTest", "pipelines": []},
+                                  ])
         self.assertEqual(
             config.get_pipeline_files(self.visit),
             [os.path.normpath(os.path.join("None shall pass", "pipelines", "SingleFrame.yaml"))]
@@ -181,52 +115,39 @@ class PipelinesConfigTest(unittest.TestCase):
                          [])
 
     def test_nomatch(self):
-        config = PipelinesConfig('''
-            -
-              survey: TestSurvey
-              pipelines: [/etc/pipelines/SingleFrame.yaml]
-            -
-              survey: CameraTest
-              pipelines: ["${AP_PIPE_DIR}/pipelines/Isr.yaml"]''')
+        config = PipelinesConfig([{"survey": "TestSurvey",
+                                   "pipelines": ["/etc/pipelines/SingleFrame.yaml"],
+                                   },
+                                  {"survey": "CameraTest",
+                                   "pipelines": ["${AP_PIPE_DIR}/pipelines/Isr.yaml"],
+                                   },
+                                  ])
         with self.assertRaises(RuntimeError):
             config.get_pipeline_files(dataclasses.replace(self.visit, survey="Surprise"))
 
     def test_empty(self):
         with self.assertRaises(ValueError):
-            PipelinesConfig('')
+            PipelinesConfig([])
         with self.assertRaises(ValueError):
             PipelinesConfig(None)
 
     def test_notlist(self):
         with self.assertRaises(ValueError):
-            PipelinesConfig('''
-              -
-                reason: TestSurvey
-                pipelines: /etc/pipelines/SingleFrame.yaml''')
+            PipelinesConfig([{"survey": "TestSurvey", "pipelines": "/etc/pipelines/SingleFrame.yaml"}])
 
     def test_oddlabel(self):
         with self.assertRaises(ValueError):
-            PipelinesConfig('''
-              -
-                reason: TestSurvey
-                pipelines: [/etc/pipelines/SingleFrame.yaml]''')
+            PipelinesConfig([{"reason": "TestSurvey", "pipelines": ["/etc/pipelines/SingleFrame.yaml"]}])
         with self.assertRaises(ValueError):
-            PipelinesConfig('''
-              -
-                survey: TestSurvey
-                comment: This is a fancy survey with simple processing.
-                pipelines: [/etc/pipelines/SingleFrame.yaml]''')
+            PipelinesConfig([{"survey": "TestSurvey",
+                              "comment": "This is a fancy survey with simple processing.",
+                              "pipelines": ["/etc/pipelines/SingleFrame.yaml"]}])
 
     def test_duplicates(self):
         with self.assertRaises(ValueError):
-            PipelinesConfig('''
-                -
-                  survey: TestSurvey
-                  pipelines:
-                  - /etc/pipelines/ApPipe.yaml
-                  - ${AP_PIPE_DIR}/pipelines/ApPipe.yaml]''')
+            PipelinesConfig([{"survey": "TestSurvey",
+                              "pipelines": ["/etc/pipelines/ApPipe.yaml",
+                                            "${AP_PIPE_DIR}/pipelines/ApPipe.yaml"]}])
         with self.assertRaises(ValueError):
-            PipelinesConfig('''
-                -
-                  survey: TestSurvey
-                  pipelines: [/etc/pipelines/ApPipe.yaml, /etc/pipelines/ApPipe.yaml#isr]''')
+            PipelinesConfig([{"survey": "TestSurvey",
+                              "pipelines": ["/etc/pipelines/ApPipe.yaml", "/etc/pipelines/ApPipe.yaml#isr"]}])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -151,3 +151,17 @@ class PipelinesConfigTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             PipelinesConfig([{"survey": "TestSurvey",
                               "pipelines": ["/etc/pipelines/ApPipe.yaml", "/etc/pipelines/ApPipe.yaml#isr"]}])
+
+    def test_order(self):
+        config = PipelinesConfig([{"survey": "TestSurvey",
+                                   "pipelines": ["/etc/pipelines/SingleFrame.yaml"],
+                                   },
+                                  {"survey": "TestSurvey",
+                                   "pipelines": ["${AP_PIPE_DIR}/pipelines/Isr.yaml"],
+                                   },
+                                  ])
+        # Second TestSurvey spec should be ignored
+        self.assertEqual(
+            config.get_pipeline_files(self.visit),
+            [os.path.normpath(os.path.join("/etc", "pipelines", "SingleFrame.yaml"))]
+        )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -58,18 +58,27 @@ class PipelinesConfigTest(unittest.TestCase):
         )
 
     def test_main_survey(self):
-        config = PipelinesConfig(
-            ' (survey="TestSurvey")=[${PROMPT_PROCESSING_DIR}/pipelines/NotACam/ApPipe.yaml]')
+        config = PipelinesConfig('''
+            -
+              survey: TestSurvey
+              pipelines:
+              - ${PROMPT_PROCESSING_DIR}/pipelines/NotACam/ApPipe.yaml''')
         self.assertEqual(
             config.get_pipeline_files(self.visit),
             [os.path.normpath(os.path.join(TESTDIR, "..", "pipelines", "NotACam", "ApPipe.yaml"))]
         )
 
     def test_selection(self):
-        config = PipelinesConfig('(survey="TestSurvey")=[/etc/pipelines/SingleFrame.yaml] '
-                                 '(survey="CameraTest")=[${AP_PIPE_DIR}/pipelines/Isr.yaml] '
-                                 '(survey="")=[Default.yaml] '
-                                 )
+        config = PipelinesConfig('''
+            -
+              survey: TestSurvey
+              pipelines: [/etc/pipelines/SingleFrame.yaml]
+            -
+              survey: CameraTest
+              pipelines: ["${AP_PIPE_DIR}/pipelines/Isr.yaml"]
+            -
+              survey: ""
+              pipelines: [Default.yaml]''')
         self.assertEqual(
             config.get_pipeline_files(self.visit),
             [os.path.normpath(os.path.join("/etc", "pipelines", "SingleFrame.yaml"))]
@@ -83,11 +92,10 @@ class PipelinesConfigTest(unittest.TestCase):
             ["Default.yaml"]
         )
 
-    def test_multiline(self):
-        config = PipelinesConfig('''(survey="TestSurvey")=[/etc/pipelines/SingleFrame.yaml]
-                                 (survey="CameraTest")=[${AP_PIPE_DIR}/pipelines/Isr.yaml]
-                                 '''
-                                 )
+    def test_singleline(self):
+        config = PipelinesConfig('[{survey: TestSurvey, pipelines: [/etc/pipelines/SingleFrame.yaml]},'
+                                 " {survey: CameraTest, pipelines: ['${AP_PIPE_DIR}/pipelines/Isr.yaml']}"
+                                 ']')
         self.assertEqual(
             config.get_pipeline_files(self.visit),
             [os.path.normpath(os.path.join("/etc", "pipelines", "SingleFrame.yaml"))]
@@ -98,9 +106,12 @@ class PipelinesConfigTest(unittest.TestCase):
         )
 
     def test_fallback(self):
-        config = PipelinesConfig('(survey="TestSurvey")=[/etc/pipelines/SingleFrame.yaml, '
-                                 '                       ${AP_PIPE_DIR}/pipelines/Isr.yaml]'
-                                 )
+        config = PipelinesConfig('''
+            -
+              survey: TestSurvey
+              pipelines:
+              - /etc/pipelines/SingleFrame.yaml
+              - ${AP_PIPE_DIR}/pipelines/Isr.yaml''')
         self.assertEqual(
             config.get_pipeline_files(self.visit),
             [os.path.normpath(os.path.join("/etc", "pipelines", "SingleFrame.yaml")),
@@ -108,9 +119,14 @@ class PipelinesConfigTest(unittest.TestCase):
         )
 
     def test_space(self):
-        config = PipelinesConfig('(survey="TestSurvey")=[/dir with space/pipelines/SingleFrame.yaml] '
-                                 '(survey="Camera Test")=[${AP_PIPE_DIR}/pipe lines/Isr.yaml] '
-                                 )
+        config = PipelinesConfig('''
+          -
+            survey: TestSurvey
+            pipelines: [/dir with space/pipelines/SingleFrame.yaml]
+          -
+            survey: Camera Test
+            pipelines:
+            - ${AP_PIPE_DIR}/pipe lines/Isr.yaml''')
         self.assertEqual(
             config.get_pipeline_files(self.visit),
             [os.path.normpath(os.path.join("/dir with space", "pipelines", "SingleFrame.yaml"))]
@@ -121,10 +137,16 @@ class PipelinesConfigTest(unittest.TestCase):
         )
 
     def test_extrachars(self):
-        config = PipelinesConfig('(survey="stylish-modern-survey")=[/etc/pipelines/SingleFrame.yaml] '
-                                 '(survey="ScriptParams4,6")=[${AP_PIPE_DIR}/pipelines/Isr.yaml] '
-                                 '(survey="slash/and\backslash")=[Default.yaml] '
-                                 )
+        config = PipelinesConfig(r'''
+            -
+              survey: stylish-modern-survey
+              pipelines: [/etc/pipelines/SingleFrame.yaml]
+            -
+              survey: ScriptParams4,6
+              pipelines: ["${AP_PIPE_DIR}/pipelines/Isr.yaml"]
+            -
+              survey: 'slash/and\backslash'
+              pipelines: [Default.yaml]''')
         self.assertEqual(
             config.get_pipeline_files(dataclasses.replace(self.visit, survey="stylish-modern-survey")),
             [os.path.normpath(os.path.join("/etc", "pipelines", "SingleFrame.yaml"))]
@@ -134,15 +156,21 @@ class PipelinesConfigTest(unittest.TestCase):
             [os.path.normpath(os.path.join(getPackageDir("ap_pipe"), "pipelines", "Isr.yaml"))]
         )
         self.assertEqual(
-            config.get_pipeline_files(dataclasses.replace(self.visit, survey="slash/and\backslash")),
+            config.get_pipeline_files(dataclasses.replace(self.visit, survey=r"slash/and\backslash")),
             ["Default.yaml"]
         )
 
     def test_none(self):
-        config = PipelinesConfig('(survey="TestSurvey")=[None shall pass/pipelines/SingleFrame.yaml] '
-                                 '(survey="Camera Test")=None '
-                                 '(survey="CameraTest")=[] '
-                                 )
+        config = PipelinesConfig('''
+            -
+              survey: TestSurvey
+              pipelines: [None shall pass/pipelines/SingleFrame.yaml]
+            -
+              survey: Camera Test
+              pipelines: None
+            -
+              survey: CameraTest
+              pipelines: []''')
         self.assertEqual(
             config.get_pipeline_files(self.visit),
             [os.path.normpath(os.path.join("None shall pass", "pipelines", "SingleFrame.yaml"))]
@@ -153,9 +181,13 @@ class PipelinesConfigTest(unittest.TestCase):
                          [])
 
     def test_nomatch(self):
-        config = PipelinesConfig('(survey="TestSurvey")=[/etc/pipelines/SingleFrame.yaml] '
-                                 '(survey="CameraTest")=[${AP_PIPE_DIR}/pipelines/Isr.yaml] '
-                                 )
+        config = PipelinesConfig('''
+            -
+              survey: TestSurvey
+              pipelines: [/etc/pipelines/SingleFrame.yaml]
+            -
+              survey: CameraTest
+              pipelines: ["${AP_PIPE_DIR}/pipelines/Isr.yaml"]''')
         with self.assertRaises(RuntimeError):
             config.get_pipeline_files(dataclasses.replace(self.visit, survey="Surprise"))
 
@@ -165,55 +197,36 @@ class PipelinesConfigTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             PipelinesConfig(None)
 
-    def test_commas(self):
+    def test_notlist(self):
         with self.assertRaises(ValueError):
-            PipelinesConfig('(survey="TestSurvey")=[/etc/pipelines/SingleFrame.yaml], '
-                            '(survey="CameraTest")=[${AP_PIPE_DIR}/pipelines/Isr.yaml] '
-                            )
-        with self.assertRaises(ValueError):
-            PipelinesConfig('(survey="TestSurvey")=[/etc/pipelines/SingleFrame.yaml],'
-                            '(survey="CameraTest")=[${AP_PIPE_DIR}/pipelines/Isr.yaml] '
-                            )
-
-    def test_bad_line_breaks(self):
-        with self.assertRaises(ValueError):
-            PipelinesConfig('''(survey="Test
-                               Survey")=[/etc/pipelines/SingleFrame.yaml]'''
-                            )
-        with self.assertRaises(ValueError):
-            PipelinesConfig('''(survey="TestSurvey")=[/etc/pipelines/
-                                                      SingleFrame.yaml]'''
-                            )
-
-    def test_unlabeled(self):
-        with self.assertRaises(ValueError):
-            PipelinesConfig('(survey="TestSurvey")=[/etc/pipelines/SingleFrame.yaml], '
-                            '("CameraTest")=[${AP_PIPE_DIR}/pipelines/Isr.yaml] '
-                            )
+            PipelinesConfig('''
+              -
+                reason: TestSurvey
+                pipelines: /etc/pipelines/SingleFrame.yaml''')
 
     def test_oddlabel(self):
         with self.assertRaises(ValueError):
-            PipelinesConfig('(reason="TestSurvey")=[/etc/pipelines/SingleFrame.yaml]')
-
-    def test_nospace(self):
+            PipelinesConfig('''
+              -
+                reason: TestSurvey
+                pipelines: [/etc/pipelines/SingleFrame.yaml]''')
         with self.assertRaises(ValueError):
-            PipelinesConfig('(survey="TestSurvey")=[/etc/pipelines/SingleFrame.yaml]'
-                            '(survey="CameraTest")=[${AP_PIPE_DIR}/pipelines/Isr.yaml]'
-                            )
-
-    def test_noequal(self):
-        with self.assertRaises(ValueError):
-            PipelinesConfig('[/etc/pipelines/SingleFrame.yaml]')
-
-        with self.assertRaises(ValueError):
-            PipelinesConfig('[/etc/pipelines/SingleFrame.yaml] '
-                            '(survey="CameraTest")=[${AP_PIPE_DIR}/pipelines/Isr.yaml] '
-                            )
+            PipelinesConfig('''
+              -
+                survey: TestSurvey
+                comment: This is a fancy survey with simple processing.
+                pipelines: [/etc/pipelines/SingleFrame.yaml]''')
 
     def test_duplicates(self):
         with self.assertRaises(ValueError):
-            PipelinesConfig('(survey="TestSurvey")=[/etc/pipelines/ApPipe.yaml,'
-                            '                       ${AP_PIPE_DIR}/pipelines/ApPipe.yaml]')
+            PipelinesConfig('''
+                -
+                  survey: TestSurvey
+                  pipelines:
+                  - /etc/pipelines/ApPipe.yaml
+                  - ${AP_PIPE_DIR}/pipelines/ApPipe.yaml]''')
         with self.assertRaises(ValueError):
-            PipelinesConfig('(survey="TestSurvey")=[/etc/pipelines/ApPipe.yaml,'
-                            '                       /etc/pipelines/ApPipe.yaml#isr]')
+            PipelinesConfig('''
+                -
+                  survey: TestSurvey
+                  pipelines: [/etc/pipelines/ApPipe.yaml, /etc/pipelines/ApPipe.yaml#isr]''')

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -66,22 +66,17 @@ skymap_name = "ops_rehersal_prep_2k_v1"
 # A pipelines config that returns the test pipelines.
 # Unless a test imposes otherwise, the first pipeline should run, and
 # the second should not be attempted.
-pipelines = PipelinesConfig('''
-    -
-      survey: SURVEY
-      pipelines:
-      - ${PROMPT_PROCESSING_DIR}/tests/data/ApPipe.yaml
-      - ${PROMPT_PROCESSING_DIR}/tests/data/SingleFrame.yaml''')
-pre_pipelines_empty = PipelinesConfig('''
-    - survey: SURVEY
-      pipelines: []''')
-pre_pipelines_full = PipelinesConfig(
-    '''-
-         survey: SURVEY
-         pipelines:
-         - ${PROMPT_PROCESSING_DIR}/tests/data/Preprocess.yaml
-         - ${PROMPT_PROCESSING_DIR}/tests/data/MinPrep.yaml
-    ''')
+pipelines = PipelinesConfig([{"survey": "SURVEY",
+                              "pipelines": ["${PROMPT_PROCESSING_DIR}/tests/data/ApPipe.yaml",
+                                            "${PROMPT_PROCESSING_DIR}/tests/data/SingleFrame.yaml",
+                                            ],
+                              }])
+pre_pipelines_empty = PipelinesConfig([{"survey": "SURVEY", "pipelines": None}])
+pre_pipelines_full = PipelinesConfig([{"survey": "SURVEY",
+                                       "pipelines": ["${PROMPT_PROCESSING_DIR}/tests/data/Preprocess.yaml",
+                                                     "${PROMPT_PROCESSING_DIR}/tests/data/MinPrep.yaml",
+                                                     ],
+                                       }])
 
 
 def fake_file_data(filename, dimensions, instrument, visit):

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -66,13 +66,21 @@ skymap_name = "ops_rehersal_prep_2k_v1"
 # A pipelines config that returns the test pipelines.
 # Unless a test imposes otherwise, the first pipeline should run, and
 # the second should not be attempted.
-pipelines = PipelinesConfig('''(survey="SURVEY")=[${PROMPT_PROCESSING_DIR}/tests/data/ApPipe.yaml,
-                                                  ${PROMPT_PROCESSING_DIR}/tests/data/SingleFrame.yaml]
-                            ''')
-pre_pipelines_empty = PipelinesConfig('(survey="SURVEY")=[]')
+pipelines = PipelinesConfig('''
+    -
+      survey: SURVEY
+      pipelines:
+      - ${PROMPT_PROCESSING_DIR}/tests/data/ApPipe.yaml
+      - ${PROMPT_PROCESSING_DIR}/tests/data/SingleFrame.yaml''')
+pre_pipelines_empty = PipelinesConfig('''
+    - survey: SURVEY
+      pipelines: []''')
 pre_pipelines_full = PipelinesConfig(
-    '''(survey="SURVEY")=[${PROMPT_PROCESSING_DIR}/tests/data/Preprocess.yaml,
-                          ${PROMPT_PROCESSING_DIR}/tests/data/MinPrep.yaml]
+    '''-
+         survey: SURVEY
+         pipelines:
+         - ${PROMPT_PROCESSING_DIR}/tests/data/Preprocess.yaml
+         - ${PROMPT_PROCESSING_DIR}/tests/data/MinPrep.yaml
     ''')
 
 


### PR DESCRIPTION
This PR replaces the bespoke pipelines config format with an extensible YAML-based format, and modifies the config semantics to behave like a prioritized list instead of a mapping. These changes will make it much easier to add new kinds of constraints to the format in the future.