### PR TITLE
DM-47591: Allow main pipeline execution if preprocessing pipeline fails

### DIFF
--- a/python/activator/exception.py
+++ b/python/activator/exception.py
@@ -22,6 +22,8 @@
 
 __all__ = ["NonRetriableError", "RetriableError", "GracefulShutdownInterrupt",
            "InvalidVisitError", "IgnorableVisit",
+           "InvalidPipelineError", "NoGoodPipelinesError",
+           "PipelinePreExecutionError", "PipelineExecutionError",
            ]
 
 
@@ -106,4 +108,29 @@ class IgnorableVisit(ValueError):
     --------
     activator.visit.SummitVisit
     activator.visit.FannedOutVisit
+    """
+
+
+class InvalidPipelineError(ValueError):
+    """Exception raised if a pipeline cannot be loaded or configured.
+    """
+
+
+class NoGoodPipelinesError(RuntimeError):
+    """Exception raised if none of the configured pipelines could be run on
+    the data.
+    """
+
+
+class PipelinePreExecutionError(RuntimeError):
+    """Exception raised if a pipeline could not be prepared for execution.
+
+    Usually chained to an internal exception.
+    """
+
+
+class PipelineExecutionError(RuntimeError):
+    """Exception raised if a pipeline attempted to run, but failed.
+
+    Usually chained to an internal exception.
     """

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -561,7 +561,12 @@ class MiddlewareInterface:
                     self._transfer_data(all_datasets, calib_datasets)
 
                 with time_this_to_bundle(bundle, action_id, "prep_butlerPreprocessTime"):
-                    self._run_preprocessing()
+                    try:
+                        self._run_preprocessing()
+                    except NoGoodPipelinesError:
+                        _log.exception("Preprocessing pipelines not runnable, trying main pipelines anyway.")
+                    except (PipelinePreExecutionError, PipelineExecutionError):
+                        _log.exception("Preprocessing pipeline failed, trying main pipelines anyway.")
 
         # IMPORTANT: do not remove or rename entries in this list. New entries can be added as needed.
         enforce_schema(bundle, {action_id: ["prep_butlerTotalTime",


### PR DESCRIPTION
This PR improves the error handling around pipeline execution, distinguishing PP execution failures from pipeline failures and ignoring the latter for preprocessing pipelines.