### PR TITLE
DM-47628: Prompt Processing does not fall back on missing PrerequisiteInputs

### DIFF
--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -1255,8 +1255,8 @@ class MiddlewareInterface:
                 with lsst.utils.timer.time_this(
                         _log, msg=f"executor.make_quantum_graph ({label})", level=logging.DEBUG):
                     qgraph = executor.make_quantum_graph(pipeline, where=data_ids)
-            except (FileNotFoundError, MissingDatasetTypeError) as e:
-                _log.error(f"Building quantum graph for {pipeline_file} failed ", exc_info=e)
+            except (FileNotFoundError, MissingDatasetTypeError):
+                _log.exception(f"Building quantum graph for {pipeline_file} failed.")
                 continue
             if len(qgraph) == 0:
                 # Diagnostic logs are the responsibility of GraphBuilder.

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -1255,7 +1255,7 @@ class MiddlewareInterface:
                 with lsst.utils.timer.time_this(
                         _log, msg=f"executor.make_quantum_graph ({label})", level=logging.DEBUG):
                     qgraph = executor.make_quantum_graph(pipeline, where=data_ids)
-            except MissingDatasetTypeError as e:
+            except (FileNotFoundError, MissingDatasetTypeError) as e:
                 _log.error(f"Building quantum graph for {pipeline_file} failed ", exc_info=e)
                 continue
             if len(qgraph) == 0:


### PR DESCRIPTION
This PR fixes a bug where failure to build a quantum graph because of missing refcats is not handled by falling back to a pipeline that doesn't need them, instead causing execution to abort.