### PR TITLE
DM-47620 Add single-frame SS association to SingleFrame.yaml

### DIFF
--- a/pipelines/LSSTComCam/SingleFrame.yaml
+++ b/pipelines/LSSTComCam/SingleFrame.yaml
@@ -1,7 +1,9 @@
-description: Single-frame pipeline specialized for LSSTComCam
+description: >-
+  Single-frame pipeline for the case in which
+  no templates exist, specialized for LSSTComCam
 
 imports:
-  - location: $PROMPT_PROCESSING_DIR/pipelines/LSSTComCam/ApPipe.yaml
+  - location: $AP_PIPE_DIR/pipelines/LSSTComCam/SingleFrame.yaml
     include:
       - processCcd
       - initialPviCore


### PR DESCRIPTION
My understanding of why I was instructed to make these changes in the particular structure I did:

As-is, SingleFrame.yaml exists in prompt_processing but nowhere else. We want a system in which ap_pipe (and ci_pipe and drp_pipe) sit on top of everything else and describe pipeline functionality via yamls. All prompt_processing pipeline yamls should reference and modify counterparts in ap_pipe. At the moment, SingleFrame.yaml is a standalone prompt_processing pipeline, so in addition to adding single-frame association to it, I was asked to also move it into ap_pipe in a traditional LSSTComCam -> _ingredients reference chain.
