### PR TITLE
DM-47750: Disable brighter fatter in AP's ISR 

### DIFF
--- a/pipelines/LSSTComCam/ApPipe.yaml
+++ b/pipelines/LSSTComCam/ApPipe.yaml
@@ -9,11 +9,6 @@ imports:
     include:
       - prompt
 tasks:
-  isr:
-    class: lsst.ip.isr.IsrTaskLSST
-    config:
-      # Temporarily turn it off until it's done in ap_pipe (DM-47750).
-      doBrighterFatter: False
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:

--- a/pipelines/LSSTComCam/SingleFrame.yaml
+++ b/pipelines/LSSTComCam/SingleFrame.yaml
@@ -7,10 +7,3 @@ imports:
     include:
       - processCcd
       - initialPviCore
-
-tasks:
-  isr:
-    class: lsst.ip.isr.IsrTaskLSST
-    config:
-      # Temporarily turn it off until it's done in ap_pipe (DM-47750).
-      doBrighterFatter: False


### PR DESCRIPTION
This PR should wait until after `prompt-base` has the new `ap_pipe` that contains  https://github.com/lsst/ap_pipe/pull/209