### PR TITLE
DM-47772: Error when preloading for pipelines that don't use templates

### DIFF
--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -696,23 +696,27 @@ class MiddlewareInterface:
         if filter:
             data_id["physical_filter"] = filter
 
-        try:
-            _log.debug("Searching for templates.")
-            templates = set(_filter_datasets(
-                self.central_butler, self.butler,
-                self._get_template_types(),
-                collections=self._collection_template,
-                data_id=data_id,
-                where="patch.region OVERLAPS search_region",
-                bind={"search_region": region},
-                find_first=True,
-                all_callback=self._mark_dataset_usage,
-            ))
-        except _MissingDatasetError as err:
-            _log.error(err)
-            templates = set()
+        types = self._get_template_types()
+        if types:
+            try:
+                _log.debug("Searching for templates.")
+                templates = set(_filter_datasets(
+                    self.central_butler, self.butler,
+                    types,
+                    collections=self._collection_template,
+                    data_id=data_id,
+                    where="patch.region OVERLAPS search_region",
+                    bind={"search_region": region},
+                    find_first=True,
+                    all_callback=self._mark_dataset_usage,
+                ))
+            except _MissingDatasetError as err:
+                _log.error(err)
+                templates = set()
+            else:
+                _log.debug("Found %d new template datasets.", len(templates))
         else:
-            _log.debug("Found %d new template datasets.", len(templates))
+            templates = set()
         return skymaps | templates
 
     def _export_calibs(self, detector_id, filter):

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -354,6 +354,18 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         # Hard to test actual pipeline output, so just check we're calling it
         mock_pre.assert_called_once()
 
+    def test_prep_butler_notemplates(self):
+        """Test that prep_butler can handle pipeline configs without templates.
+        """
+        self.interface.main_pipelines = pre_pipelines_empty
+        with unittest.mock.patch("activator.middleware_interface.MiddlewareInterface._run_preprocessing") \
+                as mock_pre, \
+                self.assertNoLogs(level="ERROR"):
+            self.interface.prep_butler()
+
+        # Hard to test actual pipeline output, so just check we're calling it
+        mock_pre.assert_called_once()
+
     # TODO: prep_butler doesn't know what kinds of calibs to expect, so can't
     # tell that there are specifically, e.g., no flats. This test should pass
     # as-is after DM-40245.


### PR DESCRIPTION
This PR fixes an error message that appears when the `nextVisit` message has a position but the service is not configured with any pipelines that use templates.