### PR TITLE
DM-47779: "Existing raws" check ignores multiple snaps

### DIFF
--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -455,10 +455,10 @@ def process_visit(expected_visit: FannedOutVisit):
                         snap,
                         expected_visit.detector,
                     )
-                if oid:
-                    _log.debug("Found object %s already present", oid)
-                    exp_id = mwi.ingest_image(oid)
-                    expid_set.add(exp_id)
+                    if oid:
+                        _log.debug("Found object %s already present", oid)
+                        exp_id = mwi.ingest_image(oid)
+                        expid_set.add(exp_id)
 
                 _log.debug("Waiting for snaps...")
                 start = time.time()


### PR DESCRIPTION
This PR fixes a bug where the service would ignore (and fruitlessly listen for) already-arrived exposures in multi-snap visits.