### PR TITLE
DM-47868: Remove "any filter" processing mode

### DIFF
--- a/pipelines/LSSTComCam/Isr-cal.yaml
+++ b/pipelines/LSSTComCam/Isr-cal.yaml
@@ -1,8 +1,14 @@
 description: >-
-  ISR-only pipeline specialized for LSSTComCam. This is a seperate
-  pipeline from the other ISR-only pipeline just for it to use
-  on raw calibration data that prompt processing does not
-  usually process, so the outputs are kept seprately.
+  ISR-only pipeline specialized for LSSTComCam. This pipeline can be run on raw
+  calibration data such as biases, and does not require a known filter.
+  Its outputs are also kept separate from science visits.
 
 imports:
   - location: $PROMPT_PROCESSING_DIR/pipelines/LSSTComCam/Isr.yaml
+tasks:
+  isr:
+    class: lsst.ip.isr.IsrTaskLSST
+    config:
+      # Can't (necessarily) preload filter-dependent calibs
+      doFlat = false
+      # TODO: need to turn off fringe support after DM-47959

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -563,7 +563,7 @@ def request_retry(e: RetriableError):
     response = flask.make_response(
         f"The server could not process the request, but it can be retried: {error}",
         503,
-        {"Retry-After": 10})
+        {"Retry-After": 30})
     return response
 
 

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -71,8 +71,6 @@ base_keep_limit = int(os.environ.get("LOCAL_REPO_CACHE_SIZE", 3))-1
 # Multipliers to base_keep_limit for refcats and templates.
 refcat_factor = int(os.environ.get("REFCATS_PER_IMAGE", 4))
 template_factor = int(os.environ.get("PATCHES_PER_IMAGE", 4))
-# Minimum number of datasets to keep for filter-dependent datasets.
-filter_floor = int(os.environ.get("FILTERS_WITH_CALIBS", 20))
 # VALIDITY-HACK: local-only calib collections break if calibs are not requested
 # in chronological order. Turn off for large development runs.
 cache_calibs = bool(int(os.environ.get("DEBUG_CACHE_CALIBS", '1')))
@@ -205,8 +203,8 @@ def make_local_cache():
         base_keep_limit,
         cache_sizes={
             # TODO: find an API that doesn't require explicit enumeration
-            "goodSeeingCoadd": template_factor * max(base_keep_limit, filter_floor),
-            "deepCoadd": template_factor * max(base_keep_limit, filter_floor),
+            "goodSeeingCoadd": template_factor * base_keep_limit,
+            "deepCoadd": template_factor * base_keep_limit,
             "uw_stars_20240524": refcat_factor * base_keep_limit,
             "uw_stars_20240228": refcat_factor * base_keep_limit,
             "uw_stars_20240130": refcat_factor * base_keep_limit,
@@ -215,11 +213,6 @@ def make_local_cache():
             "gaia_dr2_20200414": refcat_factor * base_keep_limit,
             "atlas_refcat2_20220201": refcat_factor * base_keep_limit,
             "the_monster_20240904": refcat_factor * base_keep_limit,
-            "eo_flat": max(base_keep_limit, filter_floor),
-            "flat": max(base_keep_limit, filter_floor),
-            "flatBootstrap": max(base_keep_limit, filter_floor),
-            "fringe": max(base_keep_limit, filter_floor),
-            "transmission_filter": max(base_keep_limit, filter_floor),
         },
     )
 

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -338,14 +338,14 @@ class MiddlewareInterface:
         self._skip_spatial_preload = False
         if self.visit.coordinateSystem != FannedOutVisit.CoordSys.ICRS:
             self._skip_spatial_preload = True
-            _log.error("Only ICRS coordinates are fully supported. "
-                       f"Got {self.visit.coordinateSystem!r} instead in {self.visit}. "
-                       "Spatial datasets won't be loaded.")
+            _log.warning("Only ICRS coordinates are fully supported. "
+                         f"Got {self.visit.coordinateSystem!r} instead in {self.visit}. "
+                         "Spatial datasets won't be loaded.")
         if self.visit.rotationSystem != FannedOutVisit.RotSys.SKY:
             self._skip_spatial_preload = True
-            _log.error("Only sky camera rotations are fully supported. "
-                       f"Got {self.visit.rotationSystem!r} instead in {self.visit}. "
-                       "Spatial datasets won't be loaded.")
+            _log.warning("Only sky camera rotations are fully supported. "
+                         f"Got {self.visit.rotationSystem!r} instead in {self.visit}. "
+                         "Spatial datasets won't be loaded.")
 
         # Deployment/version ID -- potentially expensive to generate.
         self._deployment = self._get_deployment()

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -287,7 +287,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         self.assertEqual(self.interface.rawIngestTask.config.failFast, True)
         self.assertEqual(self.interface.rawIngestTask.config.transfer, "copy")
 
-    def _check_imports(self, butler, group, detector, expected_shards):
+    def _check_imports(self, butler, group, detector, expected_shards, have_filter=True):
         """Test that the butler has the expected supporting data.
         """
         self.assertEqual(butler.get('camera',
@@ -315,13 +315,14 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                           # TODO DM-46178: add query by validity range.
                           collections=self.umbrella)
         )
-        self.assertTrue(
-            butler.exists('flat', detector=detector, instrument='LSSTComCamSim',
-                          physical_filter=filter,
-                          full_check=True,
-                          # TODO DM-46178: add query by validity range.
-                          collections=self.umbrella)
-        )
+        if have_filter:
+            self.assertTrue(
+                butler.exists('flat', detector=detector, instrument='LSSTComCamSim',
+                              physical_filter=filter,
+                              full_check=True,
+                              # TODO DM-46178: add query by validity range.
+                              collections=self.umbrella)
+            )
         # Check that we got a model (only one in the test data)
         self.assertTrue(
             butler.exists('pretrainedModelPackage',
@@ -329,25 +330,26 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                           collections=self.umbrella)
         )
 
-        # Check that the right templates are in the chained output collection.
-        # Need to refresh the butler to get all the dimensions/collections.
-        butler.registry.refresh()
-        for patch in (142, 143, 158, 159, 160, 161, 175, 176, 177, 178,
-                      192, 193, 194, 195, 210, 211,):
-            with self.subTest(tract=7445, patch=patch):
-                self.assertTrue(
-                    butler.exists('goodSeeingCoadd', tract=7445, patch=patch, band="g",
+        if have_filter:
+            # Check that the right templates are in the chained output collection.
+            # Need to refresh the butler to get all the dimensions/collections.
+            butler.registry.refresh()
+            for patch in (142, 143, 158, 159, 160, 161, 175, 176, 177, 178,
+                          192, 193, 194, 195, 210, 211,):
+                with self.subTest(tract=7445, patch=patch):
+                    self.assertTrue(
+                        butler.exists('goodSeeingCoadd', tract=7445, patch=patch, band="g",
+                                      skymap=skymap_name,
+                                      full_check=True,
+                                      collections=self.umbrella)
+                    )
+            with self.subTest(tract=7445, patch=0):
+                self.assertFalse(
+                    butler.exists('goodSeeingCoadd', tract=7445, patch=0, band="g",
                                   skymap=skymap_name,
                                   full_check=True,
                                   collections=self.umbrella)
                 )
-        with self.subTest(tract=7445, patch=0):
-            self.assertFalse(
-                butler.exists('goodSeeingCoadd', tract=7445, patch=0, band="g",
-                              skymap=skymap_name,
-                              full_check=True,
-                              collections=self.umbrella)
-            )
 
         # Check that preloaded datasets have been generated
         date = datetime.datetime.now(datetime.timezone(datetime.timedelta(hours=-12)))
@@ -411,7 +413,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
 
         expected_shards = {166464, 177536}
         self._check_imports(self.interface.butler, group="1", detector=4,
-                            expected_shards=expected_shards)
+                            expected_shards=expected_shards, have_filter=False)
 
         # Hard to test actual pipeline output, so just check we're calling it
         mock_pre.assert_called_once()


### PR DESCRIPTION
This PR switches Prompt Processing's behavior on `filters=""` visits from preloading calibs for all filters to not preloading filter-dependent datasets at all. This keeps PP deployments from needing to be configured with much larger caches than they would otherwise need. This PR partially reverts #215, though it still _handles_ blank filters instead of generating an invalid query.