### PR TITLE
DM-48095: AP pipeline does not do solar system association

### DIFF
--- a/pipelines/HSC/ApPipe.yaml
+++ b/pipelines/HSC/ApPipe.yaml
@@ -11,4 +11,6 @@ tasks:
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:
-      doSolarSystemAssociation: false  # No "known objects" catalog for fake visits
+      # No "known objects" catalog for fake visits, but safe to run?
+      # TODO: safe to move to ap_pipe?
+      doSolarSystemAssociation: true

--- a/pipelines/LATISS/ApPipe.yaml
+++ b/pipelines/LATISS/ApPipe.yaml
@@ -14,3 +14,6 @@ tasks:
     config:
       # Alert distribution only runnable in PP environment.
       alertPackager.doProduceAlerts: True
+      # No "known objects" catalog for fake visits, but safe to run?
+      # TODO: safe to move to ap_pipe?
+      doSolarSystemAssociation: true

--- a/pipelines/LSSTComCam/ApPipe.yaml
+++ b/pipelines/LSSTComCam/ApPipe.yaml
@@ -14,3 +14,5 @@ tasks:
     config:
       # Alert distribution only runnable in PP environment.
       alertPackager.doProduceAlerts: True
+      # Associate sources from mpSkyEphemerisQuery. Safe to move to ap_pipe?
+      doSolarSystemAssociation: True

--- a/pipelines/LSSTComCamSim/ApPipe.yaml
+++ b/pipelines/LSSTComCamSim/ApPipe.yaml
@@ -14,3 +14,6 @@ tasks:
     config:
       # Alert distribution only runnable in PP environment.
       alertPackager.doProduceAlerts: True
+      # No "known objects" catalog for fake visits, but safe to run?
+      # TODO: safe to move to ap_pipe?
+      doSolarSystemAssociation: true


### PR DESCRIPTION
This PR temporarily turns on solar system association for ComCam diaPipe, so that we can test it in production.