### PR TITLE
DM-48095: AP pipeline does not do solar system association

### DIFF
--- a/pipelines/HSC/ApPipe.yaml
+++ b/pipelines/HSC/ApPipe.yaml
@@ -7,8 +7,3 @@ imports:
 parameters:
   # Use dataset's specific templates
   coaddName: goodSeeing
-tasks:
-  diaPipe:
-    class: lsst.ap.association.DiaPipelineTask
-    config:
-      doSolarSystemAssociation: false  # No "known objects" catalog for fake visits

--- a/pipelines/HSC/ApPipe.yaml
+++ b/pipelines/HSC/ApPipe.yaml
@@ -11,6 +11,4 @@ tasks:
   diaPipe:
     class: lsst.ap.association.DiaPipelineTask
     config:
-      # No "known objects" catalog for fake visits, but safe to run?
-      # TODO: safe to move to ap_pipe?
-      doSolarSystemAssociation: true
+      doSolarSystemAssociation: false  # No "known objects" catalog for fake visits

--- a/pipelines/LATISS/ApPipe.yaml
+++ b/pipelines/LATISS/ApPipe.yaml
@@ -14,6 +14,3 @@ tasks:
     config:
       # Alert distribution only runnable in PP environment.
       alertPackager.doProduceAlerts: True
-      # No "known objects" catalog for fake visits, but safe to run?
-      # TODO: safe to move to ap_pipe?
-      doSolarSystemAssociation: true

--- a/pipelines/LSSTComCam/ApPipe.yaml
+++ b/pipelines/LSSTComCam/ApPipe.yaml
@@ -14,5 +14,3 @@ tasks:
     config:
       # Alert distribution only runnable in PP environment.
       alertPackager.doProduceAlerts: True
-      # Associate sources from mpSkyEphemerisQuery. Safe to move to ap_pipe?
-      doSolarSystemAssociation: True

--- a/pipelines/LSSTComCamSim/ApPipe.yaml
+++ b/pipelines/LSSTComCamSim/ApPipe.yaml
@@ -14,6 +14,3 @@ tasks:
     config:
       # Alert distribution only runnable in PP environment.
       alertPackager.doProduceAlerts: True
-      # No "known objects" catalog for fake visits, but safe to run?
-      # TODO: safe to move to ap_pipe?
-      doSolarSystemAssociation: true


### PR DESCRIPTION
This PR removes the overrides for solar system processing, which are now centralized in lsst/ap_association#261.

This PR can only be tested once we have a base container containing the Science Pipelines changes.