### PR TITLE
DM-47973: Support Keda in MiddlewareInterface._get_deployment

### DIFF
--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -387,6 +387,7 @@ class MiddlewareInterface:
         packages = lsst.utils.packages.getAllPythonDistributions()
         packagehash = hashlib.md5(usedforsecurity=False)
         for package, version in sorted(packages.items()):
+            _log_trace3.debug("Deployment includes %s %s.", package, version)
             packagehash.update(bytes(package + version, encoding="utf-8"))
 
         # APDB config is included in pipeline/task configs.

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -382,14 +382,16 @@ class MiddlewareInterface:
         try:
             # Defined by Knative in containers, guaranteed to be unique for
             # each deployment. Currently of the form prompt-proto-service-#####.
-            return os.environ["K_REVISION"]
+            version = os.environ["K_REVISION"]
         except KeyError:
             # If not in a container, read the active Science Pipelines install.
             packages = lsst.utils.packages.Packages.fromSystem()  # Takes several seconds!
             h = hashlib.md5(usedforsecurity=False)
             for package, version in packages.items():
                 h.update(bytes(package + version, encoding="utf-8"))
-            return f"local-{h.hexdigest()}"
+            version = f"local-{h.hexdigest()}"
+        _log.debug("Deployment identified as %s.", version)
+        return version
 
     def _init_local_butler(self, repo_uri: str, output_collections: list[str], output_run: str):
         """Prepare the local butler to ingest into and process from.

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -214,7 +214,6 @@ class MiddlewareInterfaceTest(unittest.TestCase):
 
         env_patcher = unittest.mock.patch.dict(os.environ,
                                                {"CONFIG_APDB": config_file.name,
-                                                "K_REVISION": "prompt-proto-service-042",
                                                 })
         env_patcher.start()
         self.addCleanup(env_patcher.stop)
@@ -247,6 +246,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                                              pre_pipelines_empty, pipelines, skymap_name,
                                              self.local_repo.name, self.local_cache,
                                              prefix="file://")
+        self.deploy_id = self.interface._deployment
 
     def test_get_butler(self):
         for butler in [get_central_butler(self.central_repo, "lsst.obs.lsst.LsstComCamSim"),
@@ -354,7 +354,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         # Check that preloaded datasets have been generated
         date = datetime.datetime.now(datetime.timezone(datetime.timedelta(hours=-12)))
         preload_collection = f"{instname}/prompt/output-{date.year:04d}-{date.month:02d}-{date.day:02d}/" \
-                             "Preload/prompt-proto-service-042"
+                             f"Preload/{self.deploy_id}"
         self.assertTrue(
             butler.exists('promptPreload_metrics', instrument=instname, group=group, detector=detector,
                           full_check=True,
@@ -910,11 +910,11 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         out_chain = self.interface._get_output_chain(date)
         self.assertEqual(out_chain, f"{instname}/prompt/output-2023-01-22")
         preload_run = self.interface._get_preload_run(date)
-        self.assertEqual(preload_run, f"{instname}/prompt/output-2023-01-22/Preload/prompt-proto-service-042")
+        self.assertEqual(preload_run, f"{instname}/prompt/output-2023-01-22/Preload/{self.deploy_id}")
         out_run = self.interface._get_output_run(filename, date)
-        self.assertEqual(out_run, f"{instname}/prompt/output-2023-01-22/ApPipe/prompt-proto-service-042")
+        self.assertEqual(out_run, f"{instname}/prompt/output-2023-01-22/ApPipe/{self.deploy_id}")
         init_run = self.interface._get_init_output_run(filename, date)
-        self.assertEqual(init_run, f"{instname}/prompt/output-2023-01-22/ApPipe/prompt-proto-service-042")
+        self.assertEqual(init_run, f"{instname}/prompt/output-2023-01-22/ApPipe/{self.deploy_id}")
 
     def test_get_template_types(self):
         template_types = self.interface._get_template_types()
@@ -1245,7 +1245,6 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
 
         env_patcher = unittest.mock.patch.dict(os.environ,
                                                {"CONFIG_APDB": config_file.name,
-                                                "K_REVISION": "prompt-proto-service-042",
                                                 })
         env_patcher.start()
         self.addCleanup(env_patcher.stop)
@@ -1279,6 +1278,7 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
                                              pre_pipelines_full, pipelines, skymap_name, local_repo.name,
                                              self.local_cache,
                                              prefix="file://")
+        self.deploy_id = self.interface._deployment
         with unittest.mock.patch("activator.middleware_interface.MiddlewareInterface._run_preprocessing"):
             self.interface.prep_butler()
         filename = "fakeRawImage.fits"
@@ -1305,9 +1305,9 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
         date = datetime.datetime.now(datetime.timezone(datetime.timedelta(hours=-12)))
         self.output_chain = f"{instname}/prompt/output-{date.year:04d}-{date.month:02d}-{date.day:02d}"
         self.preprocessing_run = f"{instname}/prompt/output-{date.year:04d}-{date.month:02d}-{date.day:02d}" \
-                                 "/Preprocess/prompt-proto-service-042"
+                                 f"/Preprocess/{self.deploy_id}"
         self.output_run = f"{instname}/prompt/output-{date.year:04d}-{date.month:02d}-{date.day:02d}" \
-                          "/ApPipe/prompt-proto-service-042"
+                          f"/ApPipe/{self.deploy_id}"
 
         with unittest.mock.patch.object(self.interface.rawIngestTask, "extractMetadata") as mock:
             mock.return_value = file_data
@@ -1375,7 +1375,7 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
         # collections to avoid transferring inputs.
         date = datetime.datetime.now(datetime.timezone(datetime.timedelta(hours=-12)))
         run = f"{instname}/prompt/output-{date.year:04d}-{date.month:02d}-{date.day:02d}/" \
-              "NoPipe/prompt-proto-service-042"
+              f"NoPipe/{self.deploy_id}"
 
         dimension_config = central_butler.dimensions.dimensionConfig
         # Need to clean up the directory iff the method fails


### PR DESCRIPTION
This PR identifies deployments by package hash by default, not just for local builds, and fixes some bugs that made the package hash less consistent than intended.