### PR TITLE
DM-46178: Use new query system in Prompt Processing

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,2 +1,2 @@
 Copyright 2022-2024 The Board of Trustees of the Leland Stanford Junior University, through SLAC National Accelerator Laboratory
-Copyright 2022-2024 University of Washington
+Copyright 2022-2025 University of Washington

--- a/bin.src/make_export.py
+++ b/bin.src/make_export.py
@@ -37,7 +37,7 @@ import yaml
 import lsst.daf.butler as daf_butler
 from lsst.utils.timer import time_this
 
-from activator.middleware_interface import _filter_datasets
+from activator.middleware_interface import _filter_datasets, _generic_query
 
 
 def _make_parser():
@@ -132,7 +132,7 @@ def _export_for_copy(butler, target_butler, wants):
                         all_types, collections_info
                     )
                 records = _filter_datasets(
-                    butler, target_butler, dataset_types, **selection
+                    butler, target_butler, _generic_query(dataset_types, **selection)
                 )
                 contents.saveDatasets(records)
 

--- a/etc/export_comCamSim.yaml
+++ b/etc/export_comCamSim.yaml
@@ -8,6 +8,7 @@ datasets:
 # to avoid MissingCollectionError when the collection does not
 # exist in the target repo.
 - collections: "*LSSTComCamSim/calib"
+  find_first: false
 
 collections:
 - expression: LSSTComCamSim/calib

--- a/etc/export_hsc_rc2.yaml
+++ b/etc/export_hsc_rc2.yaml
@@ -1,7 +1,10 @@
 datasets:
 - collections: HSC/runs/RC2/w_2022_44/DM-36763
   datasetType: goodSeeingCoadd
+  find_first: false
 - collections: refcats*
+  find_first: false
+  limit:
 - collections: skymaps
   dataId:
     skymap: hsc_rings_v1
@@ -11,6 +14,7 @@ datasets:
 # to avoid MissingCollectionError when the collection does not
 # exist in the target repo.
 - collections: "*HSC/calib"
+  find_first: false
 collections:
 - expression: HSC/calib
   flattenChains: True

--- a/etc/export_latiss.yaml
+++ b/etc/export_latiss.yaml
@@ -3,8 +3,12 @@ datasets:
   datasetType: goodSeeingCoadd
 - collections: refcats*
   datasetType: atlas_refcat2_20220201
+  find_first: false
+  limit:
 - collections: refcats*
   datasetType: gaia_dr3_20230707
+  find_first: false
+  limit:
 - collections: skymaps
   datasetType: skyMap
 # Workaround for DM-43294: use a matching expression rather than
@@ -12,6 +16,7 @@ datasets:
 # to avoid MissingCollectionError when the collection does not
 # exist in the target repo.
 - collections: "*LATISS/calib"
+  find_first: false
 - collections: pretrained_models
   datasetType: pretrainedModelPackage
 collections:

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -912,25 +912,6 @@ class MiddlewareInterface:
                     present.remove(missing)
             dest.setCollectionChain(chain, present)
 
-    # VALIDITY-HACK: used only for local "latest calibs" collection
-    def _get_local_calib_collection(self, parent):
-        """Generate a name for a local-only calib collection to store mock
-        associations.
-
-        Parameters
-        ----------
-        parent : `str`
-            The chain that serves as the calib interface for the rest of
-            this class.
-
-        Returns
-        -------
-        calib_collection : `str`
-            The calibration collection name to use. This method does *not*
-            create the collection itself.
-        """
-        return f"{parent}/{self._day_obs}"
-
     def _export_calib_associations(self, calib_collection, datasets):
         """Export the associations between a set of datasets and a
         calibration collection.
@@ -950,15 +931,15 @@ class MiddlewareInterface:
         # latest calibs as of today. Already-cached calibs are still available
         # from previous collections.
         if datasets:
-            calib_latest = self._get_local_calib_collection(calib_collection)
-            new = self.butler.registry.registerCollection(calib_latest, CollectionType.CALIBRATION)
+            calib_daily = f"{calib_collection}/{self._day_obs}"
+            new = self.butler.registry.registerCollection(calib_daily, CollectionType.CALIBRATION)
             if new:
-                self.butler.collections.prepend_chain(calib_collection, [calib_latest])
+                self.butler.collections.prepend_chain(calib_collection, [calib_daily])
 
             # VALIDITY-HACK: real associations are expensive to query. Just apply
             # arbitrary ones and assume that the first collection in the chain is
             # always the best.
-            self.butler.registry.certify(calib_latest, datasets, Timespan(None, None))
+            self.butler.registry.certify(calib_daily, datasets, Timespan(None, None))
 
     @staticmethod
     def _count_by_type(refs):

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -1050,7 +1050,7 @@ class MiddlewareInterface:
         run : `str`
             The run in which to place preload/pre-execution products.
         """
-        return self._get_output_run("Preload", date)
+        return self._get_output_run("NoPipeline", date)
 
     def _get_init_output_run(self,
                              pipeline_file: str,

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -1848,7 +1848,8 @@ def _filter_datasets(src_repo: Butler,
         src_datasets = set()
         for dataset_type in dataset_types:
             # explain=False because empty query result is ok here and we don't need it to raise an error.
-            src_datasets |= set(src_repo.query_datasets(dataset_type, explain=False, *args, **kwargs))
+            src_datasets |= set(src_repo.query_datasets(dataset_type, explain=False,
+                                with_dimension_records=True, *args, **kwargs))
         # In many contexts, src_datasets is too large to print.
         _log_trace3.debug("Source datasets: %s", src_datasets)
     if calib_date:

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -927,6 +927,18 @@ class MiddlewareInterface:
             certified in ``calib_collection`` in the central repo, and must
             exist in the local repo.
         """
+        dataset_types = {ref.datasetType for ref in datasets}
+        associations = {}
+        for dataset_type in dataset_types:
+            associations.update(
+                (a.ref, a) for a in self.central_butler.registry.queryDatasetAssociations(
+                    dataset_type,
+                    calib_collection,
+                    collectionTypes={CollectionType.CALIBRATION},
+                    flattenChains=True
+                )
+            )
+
         # VALIDITY-HACK: (re)define a calibration collection containing the
         # latest calibs as of today. Already-cached calibs are still available
         # from previous collections.
@@ -936,10 +948,12 @@ class MiddlewareInterface:
             if new:
                 self.butler.collections.prepend_chain(calib_collection, [calib_daily])
 
-            # VALIDITY-HACK: real associations are expensive to query. Just apply
-            # arbitrary ones and assume that the first collection in the chain is
-            # always the best.
-            self.butler.registry.certify(calib_daily, datasets, Timespan(None, None))
+        for dataset in datasets:
+            association = associations[dataset]
+            # certify is designed to work on groups of datasets; in practice,
+            # the total number of calibs (~1 of each type) is small enough that
+            # grouping by timespan isn't worth it.
+            self.butler.registry.certify(calib_daily, [dataset], association.timespan)
 
     @staticmethod
     def _count_by_type(refs):

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -42,8 +42,8 @@ import lsst.sphgeom
 import lsst.afw.cameraGeom
 import lsst.ctrl.mpexec
 from lsst.ctrl.mpexec import SeparablePipelineExecutor, SingleQuantumExecutor, MPGraphExecutor
-from lsst.daf.butler import Butler, CollectionType, DatasetType, Timespan
-from lsst.daf.butler import DataIdValueError, MissingDatasetTypeError
+from lsst.daf.butler import Butler, CollectionType, DatasetType, Timespan, \
+    DataIdValueError, MissingDatasetTypeError
 import lsst.dax.apdb
 import lsst.geom
 import lsst.obs.base

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -850,12 +850,6 @@ class MiddlewareInterface:
             _check_transfer_completion(datasets, transferred, "Downloaded")
 
         with lsst.utils.timer.time_this(_log, msg="prep_butler (transfer collections)", level=logging.DEBUG):
-            # VALIDITY-HACK: ensure local <instrument>/calibs is a
-            # chain even if central collection isn't.
-            self.butler.registry.registerCollection(
-                self.instrument.makeCalibrationCollectionName(),
-                CollectionType.CHAINED,
-            )
             self._export_collections(self._collection_template)
             self._export_collections(self.instrument.makeUmbrellaCollectionName())
 
@@ -869,10 +863,6 @@ class MiddlewareInterface:
             self.instrument.makeUmbrellaCollectionName(),
             [self._collection_template,
              self.instrument.makeDefaultRawIngestRunName(),
-             # VALIDITY-HACK: account for case where source
-             # collection was CALIBRATION or omitted from
-             # umbrella.
-             self.instrument.makeCalibrationCollectionName(),
              ])
 
     def _export_collections(self, collection):
@@ -892,25 +882,14 @@ class MiddlewareInterface:
 
         # Store collection chains after all children guaranteed to exist
         chains = {}
-        removed = set()
         for child in src.queryCollections(collection, flattenChains=True, includeChains=True):
-            # VALIDITY-HACK: do not transfer calibration collections; we'll make our own
-            if src.getCollectionType(child) == CollectionType.CALIBRATION:
-                removed.add(child)
-                continue
             if src.getCollectionType(child) == CollectionType.CHAINED:
                 chains[child] = src.getCollectionChain(child)
             dest.registerCollection(child,
                                     src.getCollectionType(child),
                                     src.getCollectionDocumentation(child))
         for chain, children in chains.items():
-            # VALIDITY-HACK: fix up chains after removing calibration
-            # collections and including local-only collections.
-            present = list(dest.getCollectionChain(chain)) + list(children)
-            for missing in removed:
-                while missing in present:
-                    present.remove(missing)
-            dest.setCollectionChain(chain, present)
+            dest.setCollectionChain(chain, children)
 
     def _export_calib_associations(self, calib_collection, datasets):
         """Export the associations between a set of datasets and a
@@ -938,22 +917,12 @@ class MiddlewareInterface:
                     flattenChains=True
                 )
             )
-
-        # VALIDITY-HACK: (re)define a calibration collection containing the
-        # latest calibs as of today. Already-cached calibs are still available
-        # from previous collections.
-        if datasets:
-            calib_daily = f"{calib_collection}/{self._day_obs}"
-            new = self.butler.registry.registerCollection(calib_daily, CollectionType.CALIBRATION)
-            if new:
-                self.butler.collections.prepend_chain(calib_collection, [calib_daily])
-
         for dataset in datasets:
             association = associations[dataset]
             # certify is designed to work on groups of datasets; in practice,
             # the total number of calibs (~1 of each type) is small enough that
             # grouping by timespan isn't worth it.
-            self.butler.registry.certify(calib_daily, [dataset], association.timespan)
+            self.butler.registry.certify(association.collection, [dataset], association.timespan)
 
     @staticmethod
     def _count_by_type(refs):

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -677,11 +677,12 @@ class MiddlewareInterface:
         _log.debug("Searching for refcats of types %s.", {t.name for t in possible_refcats})
         refcats = set(_filter_datasets(
                       self.central_butler, self.butler,
-                      possible_refcats,
-                      collections=self.instrument.makeRefCatCollectionName(),
-                      where="htm7.region OVERLAPS search_region",
-                      bind={"search_region": region},
-                      find_first=True,
+                      _generic_query(possible_refcats,
+                                     collections=self.instrument.makeRefCatCollectionName(),
+                                     where="htm7.region OVERLAPS search_region",
+                                     bind={"search_region": region},
+                                     find_first=True,
+                                     ),
                       all_callback=self._mark_dataset_usage,
                       ))
         if refcats:
@@ -709,10 +710,11 @@ class MiddlewareInterface:
         """
         skymaps = set(_filter_datasets(
             self.central_butler, self.butler,
-            ["skyMap"],
-            skymap=self.skymap_name,
-            collections=self._collection_skymap,
-            find_first=True,
+            _generic_query(["skyMap"],
+                           skymap=self.skymap_name,
+                           collections=self._collection_skymap,
+                           find_first=True,
+                           ),
             all_callback=self._mark_dataset_usage,
         ))
         _log.debug("Found %d new skymap datasets.", len(skymaps))
@@ -731,12 +733,13 @@ class MiddlewareInterface:
                 _log.debug("Searching for templates.")
                 templates = set(_filter_datasets(
                     self.central_butler, self.butler,
-                    types,
-                    collections=self._collection_template,
-                    data_id=data_id,
-                    where="patch.region OVERLAPS search_region",
-                    bind={"search_region": region},
-                    find_first=True,
+                    _generic_query(types,
+                                   collections=self._collection_template,
+                                   data_id=data_id,
+                                   where="patch.region OVERLAPS search_region",
+                                   bind={"search_region": region},
+                                   find_first=True,
+                                   ),
                     all_callback=self._mark_dataset_usage,
                 ))
             except _MissingDatasetError as err:
@@ -787,11 +790,12 @@ class MiddlewareInterface:
         type_names = self.central_butler.collections._filter_dataset_types(type_names, collections_info)
         calibs = set(_filter_datasets(
             self.central_butler, self.butler,
-            type_names,
-            collections=self.instrument.makeCalibrationCollectionName(),
-            data_id=data_id,
-            find_first=True,
-            calib_date=calib_date,
+            _generic_query(type_names,
+                           collections=self.instrument.makeCalibrationCollectionName(),
+                           data_id=data_id,
+                           find_first=True,
+                           calib_date=calib_date,
+                           ),
             all_callback=self._mark_dataset_usage,
         ))
         if calibs:
@@ -816,9 +820,10 @@ class MiddlewareInterface:
         try:
             models = set(_filter_datasets(
                 self.central_butler, self.butler,
-                ["pretrainedModelPackage"],
-                collections=self._collection_ml_model,
-                find_first=True,
+                _generic_query(["pretrainedModelPackage"],
+                               collections=self._collection_ml_model,
+                               find_first=True,
+                               ),
                 all_callback=self._mark_dataset_usage,
             ))
         except _MissingDatasetError as err:
@@ -1770,21 +1775,20 @@ class _NoPositionError(RuntimeError):
     """
 
 
-# TODO: refactor this function so that querying the src repo (with timestamp),
-# querying the dest repo (without timestamp), and differencing the two are
-# properly separated.
+_DatasetResults: typing.TypeAlias = collections.abc.Iterable[lsst.daf.butler.DatasetRef]
+"""Type alias for dataset query results, to simplify annotations."""
+
+
 def _filter_datasets(src_repo: Butler,
                      dest_repo: Butler,
-                     dataset_types: collections.abc.Iterable[str | lsst.daf.butler.DatasetType],
-                     *args,
-                     calib_date: astropy.time.Time | None = None,
+                     query: collections.abc.Callable[[Butler, str], _DatasetResults],
                      all_callback: typing.Callable[[collections.abc.Iterable[lsst.daf.butler.DatasetRef]],
                                                    typing.Any] | None = None,
-                     **kwargs) -> collections.abc.Iterable[lsst.daf.butler.DatasetRef]:
+                     ) -> _DatasetResults:
     """Identify datasets in a source repository, filtering out those already
     present in a destination.
 
-    This method raises if nothing in the source repository matches the query criteria.
+    This function raises if nothing in the source repository matches the query criteria.
 
     Parameters
     ----------
@@ -1792,82 +1796,102 @@ def _filter_datasets(src_repo: Butler,
         The repository in which a dataset must be present.
     dest_repo : `lsst.daf.butler.Butler`
         The repository in which a dataset must not be present.
+    query : callable
+        A callable that takes a `~lsst.daf.butler.Butler` and a logging label
+        and returns matching datasets. The query must be valid for both
+        ``src_repo`` and ``dest_repo``.
+    all_callback: callable, optional
+        If provided, a callable that is called with *all* datasets picked up by
+        the query, before filtering out those already present in ``dest_repo``.
+        This callable is not called if the query returns no results.
+
+    Returns
+    -------
+    datasets : iterable [`lsst.daf.butler.DatasetRef`]
+        The datasets that exist in ``src_repo`` but not ``dest_repo``.
+        datasetRefs are guaranteed to be fully expanded if any only if
+        ``query`` guarantees it.
+
+    Raises
+    ------
+    _MissingDatasetError
+        Raised if the query on ``src_repo`` failed to find any datasets.
+    """
+    known_datasets = query(dest_repo, "known datasets")
+
+    # Let exceptions from src_repo query raise: if it fails, that invalidates
+    # this operation.
+    src_datasets = set(query(src_repo, "source datasets"))
+    if not src_datasets:
+        # The downstream method decides what to do with empty results.
+        # DM-40245 and DM-46178 may change this.
+        raise _MissingDatasetError("Source repo query found no matches.")
+    if all_callback:
+        all_callback(src_datasets)
+    return itertools.filterfalse(lambda ref: ref in known_datasets, src_datasets)
+
+
+def _generic_query(dataset_types: collections.abc.Iterable[str | lsst.daf.butler.DatasetType],
+                   *args,
+                   calib_date: astropy.time.Time | None = None,
+                   **kwargs) -> collections.abc.Callable[[Butler, str], _DatasetResults]:
+    """Generate a parameterized Butler dataset query.
+
+    Parameters
+    ----------
     dataset_types : iterable [`str` | `lsst.daf.butler.DatasetType`]
         Iterable of dataset type object or name to search for.
     calib_date : `astropy.time.Time`, optional
         If provided, also filter anything other than calibs valid at
         ``calib_date`` and check that at least one valid calib was found.
-    all_callback: callable, optional
-        If provided, a callable that is called with *all* datasets picked up by
-        the query, before filtering out those already present in ``dest_repo``.
-        This callable is not called if the query returns no results.
     *args, **kwargs
         Parameters for describing the dataset query. They have the same
-        meanings as the parameters of `lsst.daf.butler.query_datasets`
-        The query must be valid for both ``src_repo`` and ``dest_repo``.
+        meanings as the parameters of `lsst.daf.butler.query_datasets`.
 
     Returns
     -------
-    datasets : iterable [`lsst.daf.butler.DatasetRef`]
-        The datasets that exist in ``src_repo`` but not ``dest_repo``. All
-        datasetRefs are fully expanded.
-
-    Raises
-    ------
-    _MissingDatasetError
-        Raised if the query on ``src_repo`` failed to find any datasets, or
-        (if ``calib_date`` is set) if none of them are currently valid.
+    query : callable
+        A callable that takes a `~lsst.daf.butler.Butler` and an optional
+        logging label and executes the dataset query, returning an iterable of
+        fully expanded `~lsst.daf.butler.DatasetRef`.
     """
     formatted_args = "dataset_types={}, {}, {}".format(
         dataset_types,
         ", ".join(repr(a) for a in args),
         ", ".join(f"{k}={v!r}" for k, v in kwargs.items()),
     )
-    # time_this automatically escalates its log to ERROR level if the code raises.
-    # Some errors are expected to happen sometimes, and we don't want those to log
-    # at the ERROR level and cause confusion.
-    with lsst.utils.timer.time_this(_log, msg=f"_filter_datasets({formatted_args}) (known datasets)",
-                                    level=logging.DEBUG):
-        known_datasets = set()
-        for dataset_type in dataset_types:
-            try:
-                # Okay to have empty results.
-                known_datasets |= set(dest_repo.query_datasets(dataset_type, explain=False, *args, **kwargs))
-            except (DataIdValueError, MissingDatasetTypeError) as e:
-                # If dimensions are invalid or dataset type never registered locally,
-                # then *any* such datasets are missing.
-                _log.debug("Pre-export query with args '%s' failed with %s", formatted_args, e)
-        _log_trace.debug("Known datasets: %s", known_datasets)
 
-    # Let exceptions from src_repo query raise: if it fails, that invalidates
-    # this operation.
-    # "expanded" dimension records are ignored for DataCoordinate equality
-    # comparison, so we only need them on src_datasets.
-    with lsst.utils.timer.time_this(_log, msg=f"_filter_datasets({formatted_args}) (source datasets)",
-                                    level=logging.DEBUG):
-        src_datasets = set()
-        for dataset_type in dataset_types:
-            # explain=False because empty query result is ok here and we don't need it to raise an error.
-            src_datasets |= set(src_repo.query_datasets(dataset_type, explain=False,
-                                with_dimension_records=True, *args, **kwargs))
-        # In many contexts, src_datasets is too large to print.
-        _log_trace3.debug("Source datasets: %s", src_datasets)
-    if calib_date:
-        src_datasets = set(_filter_calibs_by_date(
-            src_repo,
-            kwargs["collections"] if "collections" in kwargs else ...,
-            src_datasets,
-            calib_date,
-        ))
-        _log_trace.debug("Sources filtered to %s: %s", calib_date.iso, src_datasets)
-    if not src_datasets:
-        # The downstream method decides what to do with empty results.
-        # DM-40245 and DM-46178 may change this.
-        raise _MissingDatasetError(
-            "Source repo query with args '{}' found no matches.".format(formatted_args))
-    if all_callback:
-        all_callback(src_datasets)
-    return itertools.filterfalse(lambda ref: ref in known_datasets, src_datasets)
+    def query(butler: Butler, butler_name: str = ""):
+        # time_this automatically escalates its log to ERROR level if the code raises.
+        # Some errors are expected to happen sometimes, and we don't want those to log
+        # at the ERROR level and cause confusion.
+        label = butler_name or str(butler)
+        with lsst.utils.timer.time_this(_log, msg=f"_generic_query({formatted_args}) ({label})",
+                                        level=logging.DEBUG):
+            datasets = set()
+            for dataset_type in dataset_types:
+                try:
+                    datasets |= set(butler.query_datasets(
+                        # explain=False because empty query result is ok here.
+                        dataset_type, explain=False, with_dimension_records=True, *args, **kwargs
+                    ))
+                except (DataIdValueError, MissingDatasetTypeError) as e:
+                    # Dimensions/dataset type often invalid for fresh local repo,
+                    # where there are no, and never have been, any matching datasets.
+                    # It *is* a problem for the central repo, but can be caught later.
+                    _log.debug("%s query failed with %s.", label, e)
+            if calib_date:
+                datasets = set(_filter_calibs_by_date(
+                    butler,
+                    kwargs["collections"] if "collections" in kwargs else ...,
+                    datasets,
+                    calib_date,
+                ))
+            # Trace3 because, in many contexts, datasets is too large to print.
+            _log_trace3.debug("%s: %s", label, datasets)
+            return datasets
+
+    return query
 
 
 def _filter_calibs_by_date(butler: Butler,

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -799,14 +799,34 @@ class MiddlewareInterface:
             data_id["physical_filter"] = filter
         type_names = self._get_calib_types()
 
+        def query_calibs_by_date(butler, label):
+            with lsst.utils.timer.time_this(_log, msg=f"Calib query ({label})", level=logging.DEBUG), \
+                    butler.query() as query:
+                expr = query.expression_factory
+                query = query.where(data_id)
+                datasets = set()
+                for dataset_type in type_names:
+                    try:
+                        datasets |= set(
+                            query.datasets(dataset_type,
+                                           self.instrument.makeCalibrationCollectionName(),
+                                           find_first=True)
+                            # where needs to come after datasets to pick up the type
+                            .where(expr[dataset_type].timespan.overlaps(calib_date))
+                            .with_dimension_records()
+                        )
+                    except (DataIdValueError, MissingDatasetTypeError) as e:
+                        # Dimensions/dataset type often invalid for fresh local repo,
+                        # where there are no, and never have been, any matching datasets.
+                        # It *is* a problem for the central repo, but can be caught later.
+                        _log.debug("%s query failed with %s.", label, e)
+                # Trace3 because, in many contexts, datasets is too large to print.
+                _log_trace3.debug("%s: %s", label, datasets)
+                return datasets
+
         calibs = set(_filter_datasets(
             self.central_butler, self.butler,
-            _generic_query(type_names,
-                           collections=self.instrument.makeCalibrationCollectionName(),
-                           data_id=data_id,
-                           find_first=True,
-                           calib_date=calib_date,
-                           ),
+            query_calibs_by_date,
             all_callback=self._mark_dataset_usage,
         ))
         if calibs:

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -942,23 +942,25 @@ class MiddlewareInterface:
             certified in ``calib_collection`` in the central repo, and must
             exist in the local repo.
         """
-        dataset_types = {ref.datasetType for ref in datasets}
-        associations = {}
-        for dataset_type in dataset_types:
-            associations.update(
-                (a.ref, a) for a in self.central_butler.registry.queryDatasetAssociations(
-                    dataset_type,
-                    calib_collection,
-                    collectionTypes={CollectionType.CALIBRATION},
-                    flattenChains=True
-                )
-            )
-        for dataset in datasets:
-            association = associations[dataset]
-            # certify is designed to work on groups of datasets; in practice,
-            # the total number of calibs (~1 of each type) is small enough that
-            # grouping by timespan isn't worth it.
-            self.butler.registry.certify(association.collection, [dataset], association.timespan)
+        collections = self.central_butler.collections
+        with self.central_butler.query() as query, \
+                self.central_butler.registry.caching_context():  # Nested loops produce lots of queries
+            for dataset in datasets:
+                dtype = dataset.datasetType
+                result = query.where(dataset.dataId) \
+                    .join_dataset_search(dtype, calib_collection) \
+                    .general(dtype.dimensions,
+                             dataset_fields={dtype.name: {"dataset_id", "run", "collection", "timespan"}},
+                             find_first=False,  # Required for timespan queries.
+                             )
+                # Associations include run membership, and possibly multiple calibration collections.
+                for association in lsst.daf.butler.DatasetAssociation.from_query_result(result, dtype):
+                    if collections.get_info(association.collection).type == CollectionType.CALIBRATION \
+                            and association.ref == dataset:
+                        # certify is designed to work on groups of datasets; in practice,
+                        # the total number of calibs (~1 of each type) is small enough that
+                        # grouping by timespan isn't worth it.
+                        self.butler.registry.certify(association.collection, [dataset], association.timespan)
 
     @staticmethod
     def _count_by_type(refs):

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -351,7 +351,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         # Check that preloaded datasets have been generated
         date = datetime.datetime.now(datetime.timezone(datetime.timedelta(hours=-12)))
         preload_collection = f"{instname}/prompt/output-{date.year:04d}-{date.month:02d}-{date.day:02d}/" \
-                             f"Preload/{self.deploy_id}"
+                             f"NoPipeline/{self.deploy_id}"
         self.assertTrue(
             butler.exists('promptPreload_metrics', instrument=instname, group=group, detector=detector,
                           full_check=True,
@@ -906,7 +906,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         out_chain = self.interface._get_output_chain(date)
         self.assertEqual(out_chain, f"{instname}/prompt/output-2023-01-22")
         preload_run = self.interface._get_preload_run(date)
-        self.assertEqual(preload_run, f"{instname}/prompt/output-2023-01-22/Preload/{self.deploy_id}")
+        self.assertEqual(preload_run, f"{instname}/prompt/output-2023-01-22/NoPipeline/{self.deploy_id}")
         out_run = self.interface._get_output_run(filename, date)
         self.assertEqual(out_run, f"{instname}/prompt/output-2023-01-22/ApPipe/{self.deploy_id}")
         init_run = self.interface._get_init_output_run(filename, date)

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -57,7 +57,7 @@ from activator.exception import NonRetriableError, NoGoodPipelinesError, Pipelin
 from activator.visit import FannedOutVisit
 from activator.middleware_interface import get_central_butler, flush_local_repo, make_local_repo, \
     _get_sasquatch_dispatcher, MiddlewareInterface, \
-    _filter_datasets, _generic_query, _filter_calibs_by_date, _MissingDatasetError
+    _filter_datasets, _generic_query, _MissingDatasetError
 
 # The short name of the instrument used in the test repo.
 instname = "LSSTComCamSim"
@@ -1175,45 +1175,6 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         result = _generic_query(["bias"], instrument=instname)(butler)
 
         self.assertEqual(result, set())
-
-    def test_filter_calibs_by_date_valid(self):
-        # _filter_calibs_by_date requires a collection, not merely an iterable
-        all_calibs = list(self.central_butler.registry.queryDatasets("bias"))
-        now_calibs = list(_filter_calibs_by_date(
-            self.central_butler, "LSSTComCamSim/calib", all_calibs,
-            astropy.time.Time("2024-06-20 00:00:00", scale="utc")
-        ))
-        self.assertEqual(len(now_calibs), 2)
-        for calib in now_calibs:
-            self.assertEqual(calib.run, "u/jchiang/bias_70240217_w_2024_07/20240218T190659Z")
-
-    def test_filter_calibs_by_date_never(self):
-        # _filter_calibs_by_date requires a collection, not merely an iterable
-        all_calibs = list(self.central_butler.registry.queryDatasets("bias"))
-        with warnings.catch_warnings():
-            # Avoid "dubious year" warnings from using a 2050 date
-            warnings.simplefilter("ignore", category=erfa.ErfaWarning)
-            future_calibs = list(_filter_calibs_by_date(
-                self.central_butler, "LSSTComCamSim/calib", all_calibs,
-                astropy.time.Time("2050-01-01 00:00:00", scale="utc")
-            ))
-        self.assertEqual(len(future_calibs), 0)
-
-    def test_filter_calibs_by_date_unbounded(self):
-        # _filter_calibs_by_date requires a collection, not merely an iterable
-        all_calibs = set(self.central_butler.registry.queryDatasets(["camera", "transmission_filter"]))
-        valid_calibs = set(_filter_calibs_by_date(
-            self.central_butler, "LSSTComCamSim/calib", all_calibs,
-            astropy.time.Time("2015-03-15 00:00:00", scale="utc")
-        ))
-        self.assertEqual(valid_calibs, all_calibs)
-
-    def test_filter_calibs_by_date_empty(self):
-        valid_calibs = set(_filter_calibs_by_date(
-            self.central_butler, "LSSTComCamSim/calib", [],
-            astropy.time.Time("2015-03-15 00:00:00", scale="utc")
-        ))
-        self.assertEqual(len(valid_calibs), 0)
 
 
 class MiddlewareInterfaceWriteableTest(unittest.TestCase):

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -57,7 +57,7 @@ from activator.exception import NonRetriableError, NoGoodPipelinesError, Pipelin
 from activator.visit import FannedOutVisit
 from activator.middleware_interface import get_central_butler, flush_local_repo, make_local_repo, \
     _get_sasquatch_dispatcher, MiddlewareInterface, \
-    _filter_datasets, _filter_calibs_by_date, _MissingDatasetError
+    _filter_datasets, _generic_query, _filter_calibs_by_date, _MissingDatasetError
 
 # The short name of the instrument used in the test repo.
 instname = "LSSTComCamSim"
@@ -1047,49 +1047,24 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                                         "dummy")
 
         combinations = [{data1, data2}, {data1, data2, data3}]
+        src_butler = unittest.mock.Mock()
+        existing_butler = unittest.mock.Mock()
         # Case where src is empty now covered in test_filter_datasets_nosrc.
         for src, existing in itertools.product(combinations, [set()] + combinations):
             diff = src - existing
-            src_butler = unittest.mock.Mock(**{"query_datasets.return_value": src})
-            existing_butler = unittest.mock.Mock(**{"query_datasets.return_value": existing})
+
+            def query(butler, _label):
+                if butler is src_butler:
+                    return src
+                elif butler is existing_butler:
+                    return existing
+                else:
+                    raise ValueError("Unknown butler!")
 
             with self.subTest(src=sorted(ref.dataId["detector"] for ref in src),
                               existing=sorted(ref.dataId["detector"] for ref in existing)):
-                result = set(_filter_datasets(src_butler, existing_butler,
-                                              ["bias"], instrument="LSSTComCamSim"))
-                src_butler.query_datasets.assert_called_once()
-                self.assertEqual(src_butler.query_datasets.call_args.args, ("bias", ))
-                # Implementation may add other kwargs.
-                self.assertEqual(src_butler.query_datasets.call_args.kwargs["instrument"], "LSSTComCamSim")
-                existing_butler.query_datasets.assert_called_once()
-                self.assertEqual(existing_butler.query_datasets.call_args.args, ("bias", ))
-                self.assertEqual(existing_butler.query_datasets.call_args.kwargs["instrument"],
-                                 "LSSTComCamSim")
+                result = set(_filter_datasets(src_butler, existing_butler, query))
                 self.assertEqual(result, diff)
-
-    def test_filter_datasets_nodim(self):
-        """Test that _filter_datasets provides the correct values when
-        the destination repository is missing not only datasets, but the
-        dimensions to define them.
-        """
-        # Much easier to create DatasetRefs with a real repo.
-        registry = self.central_butler.registry
-        data1 = self._make_expanded_ref(registry, "skyMap", {"skymap": skymap_name}, "dummy")
-
-        src_butler = unittest.mock.Mock(
-            **{"query_datasets.return_value": {data1}})
-        existing_butler = unittest.mock.Mock(
-            **{"query_datasets.side_effect":
-               lsst.daf.butler.registry.DataIdValueError(
-                   f"Unknown values specified for governor dimension skymap: {{{skymap_name}}}")
-               })
-
-        result = set(_filter_datasets(src_butler, existing_butler, ["skyMap"], ..., skymap="mymap"))
-        src_butler.query_datasets.assert_called_once()
-        self.assertEqual(src_butler.query_datasets.call_args.args, ("skyMap", ...))
-        # Implementation may add other kwargs.
-        self.assertEqual(src_butler.query_datasets.call_args.kwargs["skymap"], "mymap")
-        self.assertEqual(result, {data1})
 
     def test_filter_datasets_nosrc(self):
         """Test that _filter_datasets reports if the datasets are missing from
@@ -1101,14 +1076,21 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         data1 = self._make_expanded_ref(registry, "bias", {"instrument": "LSSTComCamSim", "detector": 1},
                                         "dummy")
 
-        src_butler = unittest.mock.Mock(
-            **{"query_datasets.return_value": set()})
+        src_butler = unittest.mock.Mock()
+        existing_butler = unittest.mock.Mock()
         for existing in [set(), {data1}]:
-            existing_butler = unittest.mock.Mock(**{"query_datasets.return_value": existing})
+
+            def query(butler, _label):
+                if butler is src_butler:
+                    return set()
+                elif butler is existing_butler:
+                    return existing
+                else:
+                    raise ValueError("Unknown butler!")
 
             with self.subTest(existing=sorted(ref.dataId["detector"] for ref in existing)):
                 with self.assertRaises(_MissingDatasetError):
-                    _filter_datasets(src_butler, existing_butler, ["bias"], instrument="LSSTComCamSim")
+                    _filter_datasets(src_butler, existing_butler, query)
 
     def test_filter_datasets_all_callback(self):
         """Test that _filter_datasets passes the correct values to its callback.
@@ -1126,15 +1108,21 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                                         "dummy")
 
         combinations = [{data1, data2}, {data1, data2, data3}]
+        src_butler = unittest.mock.Mock()
+        existing_butler = unittest.mock.Mock()
         # Case where src is empty covered below.
         for src, existing in itertools.product(combinations, [set()] + combinations):
-            src_butler = unittest.mock.Mock(
-                **{"query_datasets.return_value": src})
-            existing_butler = unittest.mock.Mock(**{"query_datasets.return_value": existing})
+            def query(butler, _label):
+                if butler is src_butler:
+                    return src
+                elif butler is existing_butler:
+                    return existing
+                else:
+                    raise ValueError("Unknown butler!")
 
             with self.subTest(src=sorted(ref.dataId["detector"] for ref in src),
                               existing=sorted(ref.dataId["detector"] for ref in existing)):
-                _filter_datasets(src_butler, existing_butler, ["bias"], instrument="LSSTComCamSim",
+                _filter_datasets(src_butler, existing_butler, query,
                                  all_callback=functools.partial(test_function, src))
 
         # Should not call
@@ -1143,14 +1131,50 @@ class MiddlewareInterfaceTest(unittest.TestCase):
             self.fail("Callback called during _MissingDatasetError.")
 
         for existing in [set()] + combinations:
-            src_butler = unittest.mock.Mock(
-                **{"query_datasets.return_value": set()})
-            existing_butler = unittest.mock.Mock(**{"query_datasets.return_value": existing})
+            def query(butler, _label):
+                if butler is src_butler:
+                    return set()
+                elif butler is existing_butler:
+                    return existing
+                else:
+                    raise ValueError("Unknown butler!")
 
             with self.subTest(existing=sorted(ref.dataId["detector"] for ref in existing)):
                 with self.assertRaises(_MissingDatasetError):
-                    _filter_datasets(src_butler, existing_butler, ["bias"], instrument="LSSTComCamSim",
-                                     all_callback=non_callable)
+                    _filter_datasets(src_butler, existing_butler, query, all_callback=non_callable)
+
+    def test_generic_query(self):
+        # Much easier to create DatasetRefs with a real repo.
+        registry = self.central_butler.registry
+        data1 = self._make_expanded_ref(registry, "bias", {"instrument": "LSSTComCamSim", "detector": 5},
+                                        "dummy")
+        data2 = self._make_expanded_ref(registry, "bias", {"instrument": "LSSTComCamSim", "detector": 0},
+                                        "dummy")
+        data3 = self._make_expanded_ref(registry, "bias", {"instrument": "LSSTComCamSim", "detector": 1},
+                                        "dummy")
+        refs = [data1, data2, data3]
+
+        butler = unittest.mock.Mock(**{"query_datasets.return_value": refs})
+        result = _generic_query(["bias"], instrument="LSSTComCamSim")(butler)
+
+        butler.query_datasets.assert_called_once()
+        self.assertEqual(butler.query_datasets.call_args.args, ("bias", ))
+        # Implementation may add other kwargs.
+        self.assertEqual(butler.query_datasets.call_args.kwargs["instrument"], "LSSTComCamSim")
+        self.assertEqual(set(result), set(refs))
+
+    def test_generic_query_nodim(self):
+        """Test that _generic_query provides the correct values when
+        a repository is missing not only datasets, but the dimensions
+        to define them.
+        """
+        butler = unittest.mock.Mock(**{
+            "query_datasets.side_effect": lsst.daf.butler.registry.DataIdValueError(
+                f"Unknown values specified for governor dimension instrument: {instname}")
+        })
+        result = _generic_query(["bias"], instrument=instname)(butler)
+
+        self.assertEqual(result, set())
 
     def test_filter_calibs_by_date_valid(self):
         # _filter_calibs_by_date requires a collection, not merely an iterable

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -1057,10 +1057,14 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                               existing=sorted(ref.dataId["detector"] for ref in existing)):
                 result = set(_filter_datasets(src_butler, existing_butler,
                                               ["bias"], instrument="LSSTComCamSim"))
-                src_butler.query_datasets.assert_called_once_with(
-                    "bias", instrument="LSSTComCamSim", explain=False)
-                existing_butler.query_datasets.assert_called_once_with(
-                    "bias", instrument="LSSTComCamSim", explain=False)
+                src_butler.query_datasets.assert_called_once()
+                self.assertEqual(src_butler.query_datasets.call_args.args, ("bias", ))
+                # Implementation may add other kwargs.
+                self.assertEqual(src_butler.query_datasets.call_args.kwargs["instrument"], "LSSTComCamSim")
+                existing_butler.query_datasets.assert_called_once()
+                self.assertEqual(existing_butler.query_datasets.call_args.args, ("bias", ))
+                self.assertEqual(existing_butler.query_datasets.call_args.kwargs["instrument"],
+                                 "LSSTComCamSim")
                 self.assertEqual(result, diff)
 
     def test_filter_datasets_nodim(self):
@@ -1081,7 +1085,10 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                })
 
         result = set(_filter_datasets(src_butler, existing_butler, ["skyMap"], ..., skymap="mymap"))
-        src_butler.query_datasets.assert_called_once_with("skyMap", ..., skymap="mymap", explain=False)
+        src_butler.query_datasets.assert_called_once()
+        self.assertEqual(src_butler.query_datasets.call_args.args, ("skyMap", ...))
+        # Implementation may add other kwargs.
+        self.assertEqual(src_butler.query_datasets.call_args.kwargs["skymap"], "mymap")
         self.assertEqual(result, {data1})
 
     def test_filter_datasets_nosrc(self):


### PR DESCRIPTION
This PR removes the workarounds added on #129 and #135 and adds new implementations of calib validity queries. It also migrates old-style queries to the current system where an equivalent exists.