### PR TITLE
DM-46178: Use new query system in Prompt Processing

### DIFF
--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,2 +1,2 @@
 Copyright 2022-2024 The Board of Trustees of the Leland Stanford Junior University, through SLAC National Accelerator Laboratory
-Copyright 2022-2024 University of Washington
+Copyright 2022-2025 University of Washington

--- a/bin.src/make_export.py
+++ b/bin.src/make_export.py
@@ -37,7 +37,7 @@ import yaml
 import lsst.daf.butler as daf_butler
 from lsst.utils.timer import time_this
 
-from activator.middleware_interface import _filter_datasets
+from activator.middleware_interface import _filter_datasets, _generic_query
 
 
 def _make_parser():
@@ -132,7 +132,7 @@ def _export_for_copy(butler, target_butler, wants):
                         all_types, collections_info
                     )
                 records = _filter_datasets(
-                    butler, target_butler, dataset_types, **selection
+                    butler, target_butler, _generic_query(dataset_types, **selection)
                 )
                 contents.saveDatasets(records)
 

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -912,25 +912,6 @@ class MiddlewareInterface:
                     present.remove(missing)
             dest.setCollectionChain(chain, present)
 
-    # VALIDITY-HACK: used only for local "latest calibs" collection
-    def _get_local_calib_collection(self, parent):
-        """Generate a name for a local-only calib collection to store mock
-        associations.
-
-        Parameters
-        ----------
-        parent : `str`
-            The chain that serves as the calib interface for the rest of
-            this class.
-
-        Returns
-        -------
-        calib_collection : `str`
-            The calibration collection name to use. This method does *not*
-            create the collection itself.
-        """
-        return f"{parent}/{self._day_obs}"
-
     def _export_calib_associations(self, calib_collection, datasets):
         """Export the associations between a set of datasets and a
         calibration collection.
@@ -950,15 +931,15 @@ class MiddlewareInterface:
         # latest calibs as of today. Already-cached calibs are still available
         # from previous collections.
         if datasets:
-            calib_latest = self._get_local_calib_collection(calib_collection)
-            new = self.butler.registry.registerCollection(calib_latest, CollectionType.CALIBRATION)
+            calib_daily = f"{calib_collection}/{self._day_obs}"
+            new = self.butler.registry.registerCollection(calib_daily, CollectionType.CALIBRATION)
             if new:
-                self.butler.collections.prepend_chain(calib_collection, [calib_latest])
+                self.butler.collections.prepend_chain(calib_collection, [calib_daily])
 
             # VALIDITY-HACK: real associations are expensive to query. Just apply
             # arbitrary ones and assume that the first collection in the chain is
             # always the best.
-            self.butler.registry.certify(calib_latest, datasets, Timespan(None, None))
+            self.butler.registry.certify(calib_daily, datasets, Timespan(None, None))
 
     @staticmethod
     def _count_by_type(refs):

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -936,7 +936,7 @@ class MiddlewareInterface:
             certified in ``calib_collection`` in the central repo, and must
             exist in the local repo.
         """
-        collections = self.central_repo.collections
+        collections = self.central_butler.collections
         with self.central_butler.query() as query:
             for dataset in datasets:
                 dtype = dataset.datasetType

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -936,6 +936,7 @@ class MiddlewareInterface:
             certified in ``calib_collection`` in the central repo, and must
             exist in the local repo.
         """
+        collections = self.central_repo.collections
         with self.central_butler.query() as query:
             for dataset in datasets:
                 dtype = dataset.datasetType
@@ -945,9 +946,10 @@ class MiddlewareInterface:
                              dataset_fields={dtype.name: {"dataset_id", "run", "collection", "timespan"}},
                              find_first=False,  # Required for timespan queries.
                              )
-                # In theory, a dataset may be certified into multiple collections.
+                # Associations include run membership, and possibly multiple calibration collections.
                 for association in lsst.daf.butler.DatasetAssociation.from_query_result(result, dtype):
-                    if association.ref == dataset:
+                    if collections.get_info(association.collection).type == CollectionType.CALIBRATION \
+                            and association.ref == dataset:
                         # certify is designed to work on groups of datasets; in practice,
                         # the total number of calibs (~1 of each type) is small enough that
                         # grouping by timespan isn't worth it.

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -1848,7 +1848,8 @@ def _filter_datasets(src_repo: Butler,
         src_datasets = set()
         for dataset_type in dataset_types:
             # explain=False because empty query result is ok here and we don't need it to raise an error.
-            src_datasets |= set(src_repo.query_datasets(dataset_type, explain=False, *args, **kwargs))
+            src_datasets |= set(src_repo.query_datasets(dataset_type, explain=False,
+                                with_dimension_records=True, *args, **kwargs))
         # In many contexts, src_datasets is too large to print.
         _log_trace3.debug("Source datasets: %s", src_datasets)
     if calib_date:

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -927,6 +927,18 @@ class MiddlewareInterface:
             certified in ``calib_collection`` in the central repo, and must
             exist in the local repo.
         """
+        dataset_types = {ref.datasetType for ref in datasets}
+        associations = {}
+        for dataset_type in dataset_types:
+            associations.update(
+                (a.ref, a) for a in self.central_butler.registry.queryDatasetAssociations(
+                    dataset_type,
+                    calib_collection,
+                    collectionTypes={CollectionType.CALIBRATION},
+                    flattenChains=True
+                )
+            )
+
         # VALIDITY-HACK: (re)define a calibration collection containing the
         # latest calibs as of today. Already-cached calibs are still available
         # from previous collections.
@@ -936,10 +948,12 @@ class MiddlewareInterface:
             if new:
                 self.butler.collections.prepend_chain(calib_collection, [calib_daily])
 
-            # VALIDITY-HACK: real associations are expensive to query. Just apply
-            # arbitrary ones and assume that the first collection in the chain is
-            # always the best.
-            self.butler.registry.certify(calib_daily, datasets, Timespan(None, None))
+        for dataset in datasets:
+            association = associations[dataset]
+            # certify is designed to work on groups of datasets; in practice,
+            # the total number of calibs (~1 of each type) is small enough that
+            # grouping by timespan isn't worth it.
+            self.butler.registry.certify(calib_daily, [dataset], association.timespan)
 
     @staticmethod
     def _count_by_type(refs):

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -42,8 +42,8 @@ import lsst.sphgeom
 import lsst.afw.cameraGeom
 import lsst.ctrl.mpexec
 from lsst.ctrl.mpexec import SeparablePipelineExecutor, SingleQuantumExecutor, MPGraphExecutor
-from lsst.daf.butler import Butler, CollectionType, DatasetType, Timespan
-from lsst.daf.butler import DataIdValueError, MissingDatasetTypeError
+from lsst.daf.butler import Butler, CollectionType, DatasetType, Timespan, \
+    DataIdValueError, MissingDatasetTypeError
 import lsst.dax.apdb
 import lsst.geom
 import lsst.obs.base

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -850,12 +850,6 @@ class MiddlewareInterface:
             _check_transfer_completion(datasets, transferred, "Downloaded")
 
         with lsst.utils.timer.time_this(_log, msg="prep_butler (transfer collections)", level=logging.DEBUG):
-            # VALIDITY-HACK: ensure local <instrument>/calibs is a
-            # chain even if central collection isn't.
-            self.butler.registry.registerCollection(
-                self.instrument.makeCalibrationCollectionName(),
-                CollectionType.CHAINED,
-            )
             self._export_collections(self._collection_template)
             self._export_collections(self.instrument.makeUmbrellaCollectionName())
 
@@ -869,10 +863,6 @@ class MiddlewareInterface:
             self.instrument.makeUmbrellaCollectionName(),
             [self._collection_template,
              self.instrument.makeDefaultRawIngestRunName(),
-             # VALIDITY-HACK: account for case where source
-             # collection was CALIBRATION or omitted from
-             # umbrella.
-             self.instrument.makeCalibrationCollectionName(),
              ])
 
     def _export_collections(self, collection):
@@ -892,25 +882,14 @@ class MiddlewareInterface:
 
         # Store collection chains after all children guaranteed to exist
         chains = {}
-        removed = set()
         for child in src.queryCollections(collection, flattenChains=True, includeChains=True):
-            # VALIDITY-HACK: do not transfer calibration collections; we'll make our own
-            if src.getCollectionType(child) == CollectionType.CALIBRATION:
-                removed.add(child)
-                continue
             if src.getCollectionType(child) == CollectionType.CHAINED:
                 chains[child] = src.getCollectionChain(child)
             dest.registerCollection(child,
                                     src.getCollectionType(child),
                                     src.getCollectionDocumentation(child))
         for chain, children in chains.items():
-            # VALIDITY-HACK: fix up chains after removing calibration
-            # collections and including local-only collections.
-            present = list(dest.getCollectionChain(chain)) + list(children)
-            for missing in removed:
-                while missing in present:
-                    present.remove(missing)
-            dest.setCollectionChain(chain, present)
+            dest.setCollectionChain(chain, children)
 
     def _export_calib_associations(self, calib_collection, datasets):
         """Export the associations between a set of datasets and a
@@ -938,22 +917,12 @@ class MiddlewareInterface:
                     flattenChains=True
                 )
             )
-
-        # VALIDITY-HACK: (re)define a calibration collection containing the
-        # latest calibs as of today. Already-cached calibs are still available
-        # from previous collections.
-        if datasets:
-            calib_daily = f"{calib_collection}/{self._day_obs}"
-            new = self.butler.registry.registerCollection(calib_daily, CollectionType.CALIBRATION)
-            if new:
-                self.butler.collections.prepend_chain(calib_collection, [calib_daily])
-
         for dataset in datasets:
             association = associations[dataset]
             # certify is designed to work on groups of datasets; in practice,
             # the total number of calibs (~1 of each type) is small enough that
             # grouping by timespan isn't worth it.
-            self.butler.registry.certify(calib_daily, [dataset], association.timespan)
+            self.butler.registry.certify(association.collection, [dataset], association.timespan)
 
     @staticmethod
     def _count_by_type(refs):

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -1057,10 +1057,14 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                               existing=sorted(ref.dataId["detector"] for ref in existing)):
                 result = set(_filter_datasets(src_butler, existing_butler,
                                               ["bias"], instrument="LSSTComCamSim"))
-                src_butler.query_datasets.assert_called_once_with(
-                    "bias", instrument="LSSTComCamSim", explain=False)
-                existing_butler.query_datasets.assert_called_once_with(
-                    "bias", instrument="LSSTComCamSim", explain=False)
+                src_butler.query_datasets.assert_called_once()
+                self.assertEqual(src_butler.query_datasets.call_args.args, ("bias", ))
+                # Implementation may add other kwargs.
+                self.assertEqual(src_butler.query_datasets.call_args.kwargs["instrument"], "LSSTComCamSim")
+                existing_butler.query_datasets.assert_called_once()
+                self.assertEqual(existing_butler.query_datasets.call_args.args, ("bias", ))
+                self.assertEqual(existing_butler.query_datasets.call_args.kwargs["instrument"],
+                                 "LSSTComCamSim")
                 self.assertEqual(result, diff)
 
     def test_filter_datasets_nodim(self):
@@ -1081,7 +1085,10 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                })
 
         result = set(_filter_datasets(src_butler, existing_butler, ["skyMap"], ..., skymap="mymap"))
-        src_butler.query_datasets.assert_called_once_with("skyMap", ..., skymap="mymap", explain=False)
+        src_butler.query_datasets.assert_called_once()
+        self.assertEqual(src_butler.query_datasets.call_args.args, ("skyMap", ...))
+        # Implementation may add other kwargs.
+        self.assertEqual(src_butler.query_datasets.call_args.kwargs["skymap"], "mymap")
         self.assertEqual(result, {data1})
 
     def test_filter_datasets_nosrc(self):


### PR DESCRIPTION
This PR removes the workarounds added on #129 and #135 and adds new implementations of calib validity queries.