### PR TITLE
DM-47975: Handle multiple messages per Keda worker in Prompt Processing

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -9,4 +9,6 @@ RUN <<EOT
   mamba install -y flask gunicorn
   mamba list ${KAFKA} | grep ${KAFKA} || mamba install -y "${KAFKA}=2.4.0"
   pip install --no-input cloudevents
+  pip install --no-input prometheus-client
+  pip install --no-input redis
 EOT

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -27,6 +27,7 @@ import functools
 import json
 import logging
 import os
+import redis
 import signal
 import socket
 import sys
@@ -38,10 +39,8 @@ import boto3
 from botocore.handlers import validate_bucket_name
 import cloudevents.http
 import confluent_kafka as kafka
-from confluent_kafka.serialization import SerializationContext, MessageField
-from confluent_kafka.schema_registry import SchemaRegistryClient
-from confluent_kafka.schema_registry.avro import AvroDeserializer
 import flask
+from prometheus_client import Gauge, start_http_server
 
 from .config import PipelinesConfig
 from .exception import GracefulShutdownInterrupt, IgnorableVisit, InvalidVisitError, \
@@ -86,26 +85,16 @@ bucket_notification_kafka_offset_reset = os.environ.get("BUCKET_NOTIFICATION_KAF
 
 # Conditionally load keda environment variables
 if platform == "keda":
-    # Kafka Schema Registry URL for next visit fan out messages
-    fan_out_schema_registry_url = os.environ["FAN_OUT_SCHEMA_REGISTRY_URL"]
-    # Kafka cluster with next visit fanned out messages.
-    fan_out_kafka_cluster = os.environ["FAN_OUT_KAFKA_CLUSTER"]
-    # Kafka group for next visit fan out messages.
-    fan_out_kafka_group_id = os.environ["FAN_OUT_KAFKA_GROUP_ID"]
-    # Kafka topic for next visit fan out messages.
-    fan_out_kafka_topic = os.environ["FAN_OUT_KAFKA_TOPIC"]
-    # Kafka topic offset for next visit fan out messages.
-    fan_out_kafka_topic_offset = os.environ["FAN_OUT_KAFKA_TOPIC_OFFSET"]
-    # Kafka Fan Out SASL Mechansim.
-    fan_out_kafka_sasl_mechanism = os.environ["FAN_OUT_KAFKA_SASL_MECHANISM"]
-    # Kafka Fan Out Security Protocol.
-    fan_out_kafka_security_protocol = os.environ["FAN_OUT_KAFKA_SECURITY_PROTOCOL"]
-    # Kafka Fan Out Consumer Username.
-    fan_out_kafka_sasl_username = os.environ["FAN_OUT_KAFKA_SASL_USERNAME"]
-    # Kafka Fan Out Consumer Password.
-    fan_out_kafka_sasl_password = os.environ["FAN_OUT_KAFKA_SASL_PASSWORD"]
     # Time to wait for fanned out messages before spawning new pod.
     fanned_out_msg_listen_timeout = int(os.environ.get("FANNED_OUT_MSG_LISTEN_TIMEOUT", 300))
+    # Redis Stream Cluster
+    redis_stream_host = os.environ["REDIS_STREAM_HOST"]
+    # Redis stream name to receive messages.
+    redis_stream_name = os.environ["REDIS_STREAM_NAME"]
+    # Redis streams group; must be worker-unique to keep workers from stealing messages for others.
+    redis_group_id = str(uuid.uuid4())
+    # Redis stream consumer group
+    redis_stream_consumer_group = os.environ["REDIS_STREAM_CONSUMER_GROUP"]
 
 _log = logging.getLogger("lsst." + __name__)
 _log.setLevel(logging.DEBUG)
@@ -197,6 +186,55 @@ def _get_local_cache():
     return make_local_cache()
 
 
+def _get_redis_streams_client():
+    """Setup of Redis Client.
+
+    Returns
+    -------
+    redis_client : `Redis`
+        Initialized redis client.
+    """
+    redis_host = redis_stream_host
+    redis_client = redis.Redis(host=redis_host)
+    return redis_client
+
+
+def redis_stream_to_fanned_out_visit(fan_out_visit_decoded):
+    """Converts redis stream to fanned out visit.
+
+    Parameters
+    ----------
+    fan_out_visit_decoded : `dict`
+      Fan out visit with string values.
+
+    Returns
+    -------
+    expected_visit : `FannedOutVisit`
+        FannedOutVisit with values converted to correct type.
+    """
+
+    # Set type as elements from Redis Streams are strings.
+    fan_out_visit_decoded["salIndex"] = int(fan_out_visit_decoded["salIndex"])
+    fan_out_visit_decoded["scriptSalIndex"] = int(fan_out_visit_decoded["scriptSalIndex"])
+    fan_out_visit_decoded["startTime"] = float(fan_out_visit_decoded["startTime"])
+    fan_out_visit_decoded["cameraAngle"] = float(fan_out_visit_decoded["cameraAngle"])
+    fan_out_visit_decoded["coordinateSystem"] = int(fan_out_visit_decoded["coordinateSystem"])
+    fan_out_visit_decoded["dome"] = int(fan_out_visit_decoded["dome"])
+    fan_out_visit_decoded["duration"] = float(fan_out_visit_decoded["duration"])
+    fan_out_visit_decoded["nimages"] = int(fan_out_visit_decoded["nimages"])
+    fan_out_visit_decoded["rotationSystem"] = int(fan_out_visit_decoded["rotationSystem"])
+    fan_out_visit_decoded["totalCheckpoints"] = float(fan_out_visit_decoded["totalCheckpoints"])
+    fan_out_visit_decoded["detector"] = int(fan_out_visit_decoded["detector"])
+    # Convert position string to list
+    position_string_list = (
+        fan_out_visit_decoded["position"].replace("[", "").replace("]", "").split(",")
+    )
+    fan_out_visit_decoded["position"] = [float(i) for i in position_string_list]
+
+    expected_visit = FannedOutVisit(**fan_out_visit_decoded)
+    return expected_visit
+
+
 def create_app():
     try:
         setup_usdf_logger(
@@ -225,21 +263,6 @@ def create_app():
         sys.exit(3)
 
 
-def dict_to_fanned_out_visit(obj, ctx):
-    """
-    Converts object literal(dict) to a Fanned Out instance.
-    Args:
-        ctx (SerializationContext): Metadata pertaining to the serialization
-            operation.
-        obj (dict): Object literal(dict)
-    """
-
-    if obj is None:
-        return None
-
-    return FannedOutVisit(**obj)
-
-
 def keda_start():
 
     try:
@@ -257,6 +280,23 @@ def keda_start():
         _get_central_butler()
         _get_local_repo()
 
+        # Start Prometheus endpoint
+        start_http_server(8000)
+
+        # Prometheus gauge setup
+        instrument_name_gauge = instrument_name.lower()
+        instances_started_keda_gauge = Gauge(
+            instrument_name_gauge + "_instances_running_keda",
+            "keda instances running with " + instrument_name_gauge + " as instrument"
+        )
+        instances_processing_keda_gauge = Gauge(
+            instrument_name_gauge + "_instances_processing_keda",
+            "keda instances performing processing with " + instrument_name_gauge + " as instrument"
+        )
+
+        # Increment gauge for instance started
+        instances_started_keda_gauge.inc()
+
         _log.info("Worker ready to handle requests.")
 
     except Exception as e:
@@ -264,66 +304,95 @@ def keda_start():
         _log.exception(e)
         sys.exit(1)
 
-    # Initialize schema registry for fan out
-    fan_out_schema_registry_conf = {'url': fan_out_schema_registry_url}
-    fan_out_schema_registry_client = SchemaRegistryClient(fan_out_schema_registry_conf)
+    try:
+        redis_client = _get_redis_streams_client()
+        redis_client.ping()
+        _log.info("Redis Streams client setup for first polling")
+    except Exception as e:
+        _log.critical("Redis Streams unexpected client error in first polling; aborting")
+        _log.exception(e)
+        sys.exit(1)
 
-    fan_out_avro_deserializer = AvroDeserializer(schema_registry_client=fan_out_schema_registry_client,
-                                                 from_dict=dict_to_fanned_out_visit)
-    fan_out_consumer_conf = {
-        "bootstrap.servers": fan_out_kafka_cluster,
-        "group.id": fan_out_kafka_group_id,
-        "auto.offset.reset": fan_out_kafka_topic_offset,
-        "sasl.mechanism": fan_out_kafka_sasl_mechanism,
-        "security.protocol": fan_out_kafka_security_protocol,
-        "sasl.username": fan_out_kafka_sasl_username,
-        "sasl.password": fan_out_kafka_sasl_password,
-        'enable.auto.commit': False
-    }
-
-    _log.info("starting fan out consumer")
-    fan_out_consumer = kafka.Consumer(fan_out_consumer_conf, logger=_log)
-    fan_out_consumer.subscribe([fan_out_kafka_topic])
     fan_out_listen_start_time = time.time()
+    consumer_polls_with_message = 0
 
     try:
         while time.time() - fan_out_listen_start_time < fanned_out_msg_listen_timeout:
 
-            fan_out_message = fan_out_consumer.poll(timeout=5)
-            if fan_out_message is None:
-                continue
-            if fan_out_message.error():
-                _log.warning("Fanned out consumer error: %s", fan_out_message.error())
-            else:
-                deserialized_fan_out_visit = fan_out_avro_deserializer(fan_out_message.value(),
-                                                                       SerializationContext(
-                                                                       fan_out_message.topic(),
-                                                                       MessageField.VALUE))
-                _log.info("Unpacked message as %r.", deserialized_fan_out_visit)
+            try:
+                fan_out_message = redis_client.xreadgroup(
+                    streams={redis_stream_name: ">"},
+                    consumername=redis_group_id,
+                    groupname=redis_stream_consumer_group,
+                    count=1,)
 
-                # Calculate time to load knative and receive message based on timestamp in Kafka message
-                _log.debug("Message timestamp %r", fan_out_message.timestamp())
-                fan_out_kafka_msg_timestamp = fan_out_message.timestamp()
-                fan_out_to_prompt_time = int(time.time() * 1000) - fan_out_kafka_msg_timestamp[1]
-                _log.debug("Seconds since fan out message delivered %r", fan_out_to_prompt_time/1000)
+                if not fan_out_message:
+                    continue
+                else:
+                    # TODO consider moving into process visit to not increment for ignorable visits.
+                    instances_processing_keda_gauge.inc()
 
-                # Commit message and close client
-                fan_out_consumer.commit(message=fan_out_message, asynchronous=False)
-                fan_out_consumer.close()
+                    consumer_polls_with_message += 1
+                    if consumer_polls_with_message >= 1:
+                        fan_out_listen_finish_time = time.time()
+                        fan_out_listen_time = fan_out_listen_finish_time - fan_out_listen_start_time
+                        _log.debug(
+                            "Seconds since last redis streams message received %r for consumer poll %r",
+                            fan_out_listen_time, consumer_polls_with_message)
 
-                try:
-                    # Process fan out visit
-                    process_visit(deserialized_fan_out_visit)
-                except Exception as e:
-                    _log.critical("Process visit failed; aborting.")
-                    _log.exception(e)
-                finally:
-                    _log.info("Processing completed for %s", socket.gethostname())
-                    break
+                    # Decode and unpack fan out message from redis stream
+                    fan_out_visit_bytes = fan_out_message[0][1][0][1]
+                    fan_out_visit_decoded = {value.decode("utf-8"):
+                                             fan_out_visit_bytes.get(value).decode("utf-8")
+                                             for value in fan_out_visit_bytes.keys()}
+                    _log.info("Unpacked message as %r.", fan_out_visit_decoded)
+
+                    expected_visit = redis_stream_to_fanned_out_visit(fan_out_visit_decoded)
+
+                    # Calculate time to receive message based on timestamp in Redis Stream message
+                    redis_streams_message_id = (fan_out_message[0][1][0][0]).decode("utf-8")
+                    message_timestamp = float(redis_streams_message_id.split('-', 1)[0].strip())
+                    fan_out_to_prompt_time = time.time() - message_timestamp/1000
+                    _log.debug("Seconds since fan out message delivered %r", fan_out_to_prompt_time)
+
+                    # Ack the redis stream message and close redis stream client
+                    redis_client.xack(redis_stream_name,
+                                      redis_stream_consumer_group,
+                                      redis_streams_message_id)
+                    redis_client.close()
+            except Exception as e:
+                _log.critical("Redis Streams unexpected error while unpacking message; aborting")
+                _log.exception(e)
+
+            try:
+                # Process fan out visit
+                process_visit(expected_visit)
+            except Exception as e:
+                _log.critical("Process visit failed; aborting.")
+                _log.exception(e)
+            finally:
+                _log.info(
+                    "Processing completed for %s.  Starting next fan out event consumer poll",
+                    socket.gethostname())
+                # Decrement gauge as processing finished.
+                instances_processing_keda_gauge.dec(1)
+
+            # Reset timer for fan out message polling and start redis client for next poll
+            fan_out_listen_start_time = time.time()
+
+            try:
+                redis_client = _get_redis_streams_client()
+                redis_client.ping()
+                _log.info("Redis Streams client setup for continued polling")
+            except Exception as e:
+                _log.critical("Redis Streams client unexpected error in continued polling; aborting")
+                _log.exception(e)
+                sys.exit(1)
 
     finally:
         # TODO Handle local registry unregistration on DM-47975
         _log.info("Finished listening for fanned out messages")
+        instances_started_keda_gauge.dec(1)
 
 
 def _graceful_shutdown(signum: int, stack_frame):

--- a/python/activator/visit.py
+++ b/python/activator/visit.py
@@ -155,6 +155,43 @@ class FannedOutVisit(BareVisit):
         return f"(groupId={self.groupId}, survey={self.survey}, " \
                f"detector={self.detector})"
 
+    def from_dict_to_fanned_out_visit(self, fan_out_visit_dict: dict):
+        """Converts dict to fanned out visit.
+
+        Parameters
+        ----------
+        fan_out_visit_dict : `dict`
+        Fan out visit with string values.
+
+        Returns
+        -------
+        expected_visit : `FannedOutVisit`
+            FannedOutVisit with values converted to correct type.
+        """
+
+        fan_out_visit_dict = asdict(self)
+
+        # Set type as elements from Redis Streams are strings.
+        fan_out_visit_dict["salIndex"] = int(fan_out_visit_dict["salIndex"])
+        fan_out_visit_dict["scriptSalIndex"] = int(fan_out_visit_dict["scriptSalIndex"])
+        fan_out_visit_dict["startTime"] = float(fan_out_visit_dict["startTime"])
+        fan_out_visit_dict["cameraAngle"] = float(fan_out_visit_dict["cameraAngle"])
+        fan_out_visit_dict["coordinateSystem"] = int(fan_out_visit_dict["coordinateSystem"])
+        fan_out_visit_dict["dome"] = int(fan_out_visit_dict["dome"])
+        fan_out_visit_dict["duration"] = float(fan_out_visit_dict["duration"])
+        fan_out_visit_dict["nimages"] = int(fan_out_visit_dict["nimages"])
+        fan_out_visit_dict["rotationSystem"] = int(fan_out_visit_dict["rotationSystem"])
+        fan_out_visit_dict["totalCheckpoints"] = float(fan_out_visit_dict["totalCheckpoints"])
+        fan_out_visit_dict["detector"] = int(fan_out_visit_dict["detector"])
+        # Convert position string to list
+        position_string_list = (
+            fan_out_visit_dict["position"].replace("[", "").replace("]", "").split(",")
+        )
+        fan_out_visit_dict["position"] = [float(i) for i in position_string_list]
+
+        expected_visit = FannedOutVisit(**fan_out_visit_dict)
+        return expected_visit
+
     def get_bare_visit(self):
         """Return visit-level info as a dict"""
         info = asdict(self)

--- a/python/activator/visit.py
+++ b/python/activator/visit.py
@@ -155,13 +155,14 @@ class FannedOutVisit(BareVisit):
         return f"(groupId={self.groupId}, survey={self.survey}, " \
                f"detector={self.detector})"
 
-    def from_dict_to_fanned_out_visit(self, fan_out_visit_dict: dict):
+    @classmethod
+    def from_dict(cls, fan_out_visit_dict: dict):
         """Converts dict to fanned out visit.
 
         Parameters
         ----------
-        fan_out_visit_dict : `dict`
-        Fan out visit with string values.
+        fan_out_visit_dict : `dict` ['str']
+            Keys and values (possibly strings) representing the visit.
 
         Returns
         -------
@@ -169,28 +170,27 @@ class FannedOutVisit(BareVisit):
             FannedOutVisit with values converted to correct type.
         """
 
-        fan_out_visit_dict = asdict(self)
-
-        # Set type as elements from Redis Streams are strings.
-        fan_out_visit_dict["salIndex"] = int(fan_out_visit_dict["salIndex"])
-        fan_out_visit_dict["scriptSalIndex"] = int(fan_out_visit_dict["scriptSalIndex"])
-        fan_out_visit_dict["startTime"] = float(fan_out_visit_dict["startTime"])
-        fan_out_visit_dict["cameraAngle"] = float(fan_out_visit_dict["cameraAngle"])
-        fan_out_visit_dict["coordinateSystem"] = int(fan_out_visit_dict["coordinateSystem"])
-        fan_out_visit_dict["dome"] = int(fan_out_visit_dict["dome"])
-        fan_out_visit_dict["duration"] = float(fan_out_visit_dict["duration"])
-        fan_out_visit_dict["nimages"] = int(fan_out_visit_dict["nimages"])
-        fan_out_visit_dict["rotationSystem"] = int(fan_out_visit_dict["rotationSystem"])
-        fan_out_visit_dict["totalCheckpoints"] = float(fan_out_visit_dict["totalCheckpoints"])
-        fan_out_visit_dict["detector"] = int(fan_out_visit_dict["detector"])
-        # Convert position string to list
-        position_string_list = (
-            fan_out_visit_dict["position"].replace("[", "").replace("]", "").split(",")
+        return FannedOutVisit(
+            salIndex=int(fan_out_visit_dict["salIndex"]),
+            scriptSalIndex=int(fan_out_visit_dict["scriptSalIndex"]),
+            groupId=str(fan_out_visit_dict["groupId"]),
+            startTime=float(fan_out_visit_dict["startTime"]),
+            cameraAngle=float(fan_out_visit_dict["cameraAngle"]),
+            coordinateSystem=cls.CoordSys(int(fan_out_visit_dict["coordinateSystem"])),
+            filters=str(fan_out_visit_dict["filters"]),
+            dome=cls.Dome(int(fan_out_visit_dict["dome"])),
+            duration=float(fan_out_visit_dict["duration"]),
+            nimages=int(fan_out_visit_dict["nimages"]),
+            instrument=str(fan_out_visit_dict["instrument"]),
+            survey=str(fan_out_visit_dict["survey"]),
+            rotationSystem=cls.RotSys(int(fan_out_visit_dict["rotationSystem"])),
+            totalCheckpoints=int(fan_out_visit_dict["totalCheckpoints"]),
+            detector=int(fan_out_visit_dict["detector"]),
+            private_sndStamp=float(fan_out_visit_dict["private_sndStamp"]),
+            # Convert position string to list
+            position=[float(i) for i in fan_out_visit_dict["position"].replace(
+                "[", "").replace("]", "").split(",")],
         )
-        fan_out_visit_dict["position"] = [float(i) for i in position_string_list]
-
-        expected_visit = FannedOutVisit(**fan_out_visit_dict)
-        return expected_visit
 
     def get_bare_visit(self):
         """Return visit-level info as a dict"""


### PR DESCRIPTION
Converts fan out message unpacking to Redis Streams with support to handle multiple messages per Keda worker.  Removes Kafka support for message unpacking of fanned out visits.  The prompt processing base image is updated with python libraries for Redis and Prometheus.  Prometheus is used to track utilization of running instances vs instances that are processing.