### PR TITLE
DM-48842: Prompt Processing query errors don't report which query failed

### DIFF
--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -746,7 +746,7 @@ class MiddlewareInterface:
                     all_callback=self._mark_dataset_usage,
                 ))
             except _MissingDatasetError as err:
-                _log.error(err)
+                _log.error("Could not load templates: %s", err)
                 templates = set()
             else:
                 _log.debug("Found %d new template datasets.", len(templates))
@@ -861,7 +861,7 @@ class MiddlewareInterface:
                 all_callback=self._mark_dataset_usage,
             ))
         except _MissingDatasetError as err:
-            _log.error(err)
+            _log.error("Could not load ML models: %s", err)
             models = set()
         else:
             _log.debug("Found %d new ML model datasets.", len(models))
@@ -1536,7 +1536,8 @@ class MiddlewareInterface:
                     output_chain = self._get_output_chain(self._day_obs)
                     self._chain_exports(output_chain, populated_runs)
                 else:
-                    _log.warning("No datasets match visit=%s and exposures=%s.", self.visit, exposure_ids)
+                    _log.warning("No output datasets match visit=%s and exposures=%s.",
+                                 self.visit, exposure_ids)
 
         finally:
             # TODO: can we use SasquatchDatastore to streamline this?

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -142,9 +142,8 @@ def flush_local_repo(repo_dir: str, central_butler: Butler):
             # Don't try to chain the runs -- only way to get the correct chain
             # name is to parse the collection name(s), too brittle for the rare
             # case that the runs aren't already in central repo.
-    except Exception as e:
-        _log.error("Could not sync outputs from %s; they will be lost.", repo_dir)
-        _log.exception(e)
+    except Exception:
+        _log.exception("Could not sync outputs from %s; they will be lost.", repo_dir)
     finally:
         # If deletion fails, raise and let the activator handle it.
         shutil.rmtree(repo_dir)

--- a/python/tester/upload.py
+++ b/python/tester/upload.py
@@ -348,7 +348,7 @@ def upload_from_raws(kafka_url, instrument, raw_pool, src_bucket, dest_bucket, n
     """
     if n_groups > len(raw_pool):
         raise ValueError(f"Requested {n_groups} groups, but only {len(raw_pool)} "
-                         "unobserved raw groups are available."
+                         "unobserved raw groups are available. "
                          "For large-scale tests, consider upload_from_repo.py.")
 
     for i, true_group in enumerate(itertools.islice(raw_pool, n_groups)):


### PR DESCRIPTION
This PR fixes some of the logs in `middleware_interface` that were left too ambiguous by the code reorganization in #249.