### PR TITLE
DM-49288: Clean up temporary files when uploading.

### DIFF
--- a/etc/tester/imsim.yaml
+++ b/etc/tester/imsim.yaml
@@ -1,0 +1,5 @@
+instrument: LSSTCam-imSim
+query:
+  collections: 2.2i/raw/OR5/DDF/day2/DM-48585
+  #where: "exposure > 1181582"
+repo: embargo_or5

--- a/etc/tester/imsim.yaml
+++ b/etc/tester/imsim.yaml
@@ -1,5 +1,5 @@
 instrument: LSSTCam-imSim
 query:
   collections: 2.2i/raw/OR5/DDF/day2/DM-48585
-  #where: "exposure > 1181582"
+  where: "exposure > 1191232"
 repo: embargo_or5

--- a/python/tester/upload_from_repo.py
+++ b/python/tester/upload_from_repo.py
@@ -143,7 +143,7 @@ def main():
     # exposure.
     _log.debug("Uploading with %d processes...", max_processes)
     with context.Pool(processes=max_processes, initializer=_set_s3_bucket) as pool, \
-            tempfile.TemporaryDirectory() as temp_dir:
+            tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
         for visit in visit_list:
             group = increment_group(instrument, group, 1)
             refs = prepare_one_visit(kafka_url, group, butler, instrument, visit)
@@ -285,7 +285,7 @@ def _get_max_processes():
         overhead, and processing speed.
     """
     try:
-        return math.ceil(0.25*multiprocessing.cpu_count())
+        return math.ceil(multiprocessing.cpu_count())
     except NotImplementedError:
         return 4
 

--- a/python/tester/upload_from_repo.py
+++ b/python/tester/upload_from_repo.py
@@ -360,7 +360,8 @@ def _upload_one_image(temp_dir, group_id, butler, ref):
                             Body=json.dumps(dict(hdul[0].header)),
                             Key=dest_key.removesuffix("fits") + "json",
                         )
-            dest_bucket.upload_file(path, dest_key)
+            with open(path, "r") as temp_file:
+                dest_bucket.put_object(Body=temp_file, Key=dest_key)
             _log.debug(f"{dest_key} was written at {dest_bucket}")
         finally:
             os.remove(path)

--- a/python/tester/upload_from_repo.py
+++ b/python/tester/upload_from_repo.py
@@ -342,6 +342,8 @@ def _upload_one_image(temp_dir, group_id, butler, ref):
             _log.error(
                 f"{ref} has multiple artifacts and cannot be handled by current implementation"
             )
+            for transfer in transferred:
+                os.remove(transfer.path)
             return
 
         path = transferred[0].path

--- a/python/tester/upload_from_repo.py
+++ b/python/tester/upload_from_repo.py
@@ -24,6 +24,7 @@ import json
 import logging
 import math
 import multiprocessing
+import os
 import random
 import tempfile
 import time
@@ -347,17 +348,20 @@ def _upload_one_image(temp_dir, group_id, butler, ref):
         _log.debug(
             f"Raw file for {ref.dataId} was copied from Butler to {path}"
         )
-        with open(path, "r+b") as temp_file:
-            for header_key in headers:
-                replace_header_key(temp_file, header_key, headers[header_key])
-            if not sidecar_uploaded:
-                with fits.open(temp_file, mode="update") as hdul:
-                    dest_bucket.put_object(
-                        Body=json.dumps(dict(hdul[0].header)),
-                        Key=dest_key.removesuffix("fits") + "json",
-                    )
-        dest_bucket.upload_file(path, dest_key)
-        _log.debug(f"{dest_key} was written at {dest_bucket}")
+        try:
+            with open(path, "r+b") as temp_file:
+                for header_key in headers:
+                    replace_header_key(temp_file, header_key, headers[header_key])
+                if not sidecar_uploaded:
+                    with fits.open(temp_file, mode="update") as hdul:
+                        dest_bucket.put_object(
+                            Body=json.dumps(dict(hdul[0].header)),
+                            Key=dest_key.removesuffix("fits") + "json",
+                        )
+            dest_bucket.upload_file(path, dest_key)
+            _log.debug(f"{dest_key} was written at {dest_bucket}")
+        finally:
+            os.remove(path)
 
 
 if __name__ == "__main__":

--- a/python/tester/upload_from_repo.py
+++ b/python/tester/upload_from_repo.py
@@ -49,7 +49,7 @@ from tester.utils import (
 )
 
 
-EXPOSURE_INTERVAL = 18
+EXPOSURE_INTERVAL = 30
 SLEW_INTERVAL = 2
 
 

--- a/python/tester/upload_from_repo.py
+++ b/python/tester/upload_from_repo.py
@@ -75,7 +75,7 @@ def _set_s3_bucket():
         global dest_bucket
         endpoint_url = "https://sdfembs3.sdf.slac.stanford.edu"
         s3 = boto3.resource("s3", endpoint_url=endpoint_url)
-        dest_bucket = s3.Bucket("repo-test") # Use or5-uploader aws profile to write there
+        dest_bucket = s3.Bucket("repo-test")  # Use or5-uploader aws profile to write there
         dest_bucket.meta.client.meta.events.unregister("before-parameter-build.s3", validate_bucket_name)
 
 

--- a/python/tester/upload_from_repo.py
+++ b/python/tester/upload_from_repo.py
@@ -73,9 +73,9 @@ def _set_s3_bucket():
     """
     with time_this(log=_log, msg="Bucket initialization", prefix=None):
         global dest_bucket
-        endpoint_url = "https://s3dfrgw.slac.stanford.edu"
+        endpoint_url = "https://sdfembs3.sdf.slac.stanford.edu"
         s3 = boto3.resource("s3", endpoint_url=endpoint_url)
-        dest_bucket = s3.Bucket("rubin-pp-dev")
+        dest_bucket = s3.Bucket("repo-test") # Use or5-uploader aws profile to write there
         dest_bucket.meta.client.meta.events.unregister("before-parameter-build.s3", validate_bucket_name)
 
 


### PR DESCRIPTION
Also avoid multipart uploads, which can sometimes cause problems in Ceph S3 and are generally not needed due to the number of parallel uploads we're doing anyway.