### PR TITLE
DM-49427: Filter out old fanned-out messages in Keda

### DIFF
--- a/doc/playbook.rst
+++ b/doc/playbook.rst
@@ -138,7 +138,8 @@ Add text as follows.
 
 Select **Publish Release**.
 
-The `ci-release.yaml <https://github.com/lsst-dm/prompt_processing/actions/workflows/ci-release.yaml>`_ GitHub Actions workflow uploads the new release to GitHub packages.
+The `Release CI <https://github.com/lsst-dm/prompt_processing/actions/workflows/ci-release.yaml>`_ GitHub Actions workflow uploads the new release to GitHub packages.
+This may take a few minutes, and the release is not usable until it succeeds.
 
 3. Tag the release
 

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -482,6 +482,9 @@ def keda_start():
                         continue
 
                     redis_session.acknowledge(redis_streams_message_id)
+
+                    expected_visit = FannedOutVisit.from_dict(fan_out_visit_decoded)
+                    _log.debug("Unpacked message as %r.", expected_visit)
                     redis_session.close()
 
                 # TODO Review Redis Errors and determine what should be retriable.
@@ -496,9 +499,6 @@ def keda_start():
 
                 with instances_processing_gauge.track_inprogress():
                     try:
-
-                        expected_visit = FannedOutVisit.from_dict(fan_out_visit_decoded)
-                        _log.debug("Unpacked message as %r.", expected_visit)
 
                         consumer_polls_with_message += 1
                         if consumer_polls_with_message >= 1:

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -761,8 +761,11 @@ def next_visit_handler() -> tuple[str, int]:
         except ValueError as e:
             _log.exception("Bad Request")
             return f"Bad Request: {e}", 400
-        process_visit(expected_visit)
-        return "Pipeline executed", 200
+        if is_processable(expected_visit, visit_expire):
+            process_visit(expected_visit)
+            return "Pipeline executed", 200
+        else:
+            return "Stale request, ignoring", 403
     except GracefulShutdownInterrupt:
         # Safety net to minimize chance of interrupt propagating out of the worker.
         # Ideally, this would be a Flask.errorhandler, but Flask ignores BaseExceptions.


### PR DESCRIPTION
This PR refactors the Redis connection management to something with lower algorithmic complexity, then adds a check to both Knative and Keda that rejects messages sent too long ago.