### PR TITLE
Add status badge for Release CI workflow

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -2,16 +2,6 @@ name: Release CI
 
 "on":
   push:
-    branches-ignore:
-      # These should always correspond to pull requests, so ignore them for
-      # the push trigger and let them be triggered by the pull_request
-      # trigger, avoiding running the workflow twice.  This is a minor
-      # optimization so there's no need to ensure this is comprehensive.
-      - "dependabot/**"
-      - "renovate/**"
-      - "releases/**"
-      - "tickets/**"
-      - "u/**"
     tags:
       - "*"
   pull_request:

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,10 @@
 prompt_processing
 #################
 
+.. image:: https://github.com/lsst-dm/prompt_processing/actions/workflows/ci-release.yaml/badge.svg?event=push
+   :target: https://github.com/lsst-dm/prompt_processing/actions/workflows/ci-release.yaml
+   :alt: Release CI Build Status
+
 ``prompt_processing`` is a package in the `LSST Science Pipelines <https://pipelines.lsst.io>`_.
 
 ``prompt_processing`` contains code used for the Rubin Observatory Prompt Processing framework.


### PR DESCRIPTION
This PR adds a badge to the readme, and fixes the Release CI workflow's trigger conditions to ignore merges to `main` (a job condition prevents these from actually running, but they still count as execution history).