### PR TITLE
DM-49477: GracefulShutdownInterrupt does not shut down Keda workers

### DIFF
--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -554,14 +554,14 @@ def keda_start():
                         # Process fan out visit
                         process_visit(expected_visit)
                         processing_result = "Success"
+                    except IgnorableVisit as e:
+                        _log.info("Skipping visit: %s", e)
+                        processing_result = "Ignore"
                     except GracefulShutdownInterrupt:
                         _log.error(
                             "Service interrupted.Shutting down *without* syncing to the central repo.")
                         processing_result = "Interrupted"
                         sys.exit(1)
-                    except IgnorableVisit as e:
-                        _log.info("Skipping visit: %s", e)
-                        processing_result = "Ignore"
                     except Exception:
                         _log.exception("Processing failed:")
                         processing_result = "Error"


### PR DESCRIPTION
This PR adds correct handling of `GracefulShutdownInterrupt` to Keda. The code is rather clunky, but I don't see a way to simplify it given the need to support retries in the future.