### PR TITLE
Expand status badges for Release CI workflow

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,6 +6,12 @@ prompt_processing
    :target: https://github.com/lsst-dm/prompt_processing/actions/workflows/build-service.yml
    :alt: Dev Build Status
 
+.. Selecting tag, not release, to catch any accidental runs of Release CI
+
+.. image:: https://img.shields.io/github/v/tag/lsst-dm/prompt_processing?sort=date&label=Release
+   :target: https://github.com/lsst-dm/prompt_processing/releases/latest
+   :alt: Latest Release
+
 .. image:: https://github.com/lsst-dm/prompt_processing/actions/workflows/ci-release.yaml/badge.svg?event=push
    :target: https://github.com/lsst-dm/prompt_processing/actions/workflows/ci-release.yaml
    :alt: Release CI Build Status

--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,10 @@
 prompt_processing
 #################
 
+.. image:: https://github.com/lsst-dm/prompt_processing/actions/workflows/build-service.yml/badge.svg?branch=main
+   :target: https://github.com/lsst-dm/prompt_processing/actions/workflows/build-service.yml
+   :alt: Dev Build Status
+
 .. image:: https://github.com/lsst-dm/prompt_processing/actions/workflows/ci-release.yaml/badge.svg?event=push
    :target: https://github.com/lsst-dm/prompt_processing/actions/workflows/ci-release.yaml
    :alt: Release CI Build Status


### PR DESCRIPTION
This PR adds a couple of extra badges to the one added in #279, to provide other info useful to developers.