### PR TITLE
DM-45988: Synchronize rebuilds on all code changes.

### DIFF
--- a/.github/workflows/build-init-job.yaml
+++ b/.github/workflows/build-init-job.yaml
@@ -6,28 +6,36 @@ on:
       - main
       - 'releases/**'
     paths:
+      # Build workflow changes
       - '.github/workflows/build-init-job.yaml'
       - '.github/workflows/_matrix-gen.yaml'
       - '.github/actions/**'
+      - 'init-output-run/Dockerfile'
+      # Code (deployment ID) changes
       - 'bin.src/write_init_outputs.py'
       - 'config/**'
       - 'pipelines/**'
+      - 'python/activator/**'
       - 'python/initializer/**'
       - 'python/shared/**'
+      # Need to re-test
       - 'tests/**'
-      - 'init-output-run/Dockerfile'
   pull_request:
     paths:
+      # Build workflow changes
       - '.github/workflows/build-init-job.yaml'
       - '.github/workflows/_matrix-gen.yaml'
       - '.github/actions/**'
+      - 'init-output-run/Dockerfile'
+      # Code (deployment ID) changes
       - 'bin.src/write_init_outputs.py'
       - 'config/**'
       - 'pipelines/**'
+      - 'python/activator/**'
       - 'python/initializer/**'
       - 'python/shared/**'
+      # Need to re-test
       - 'tests/**'
-      - 'init-output-run/Dockerfile'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/build-service.yml
+++ b/.github/workflows/build-service.yml
@@ -6,26 +6,36 @@ on:
       - main
       - 'releases/**'
     paths:
+      # Build workflow changes
       - '.github/workflows/build-service.yml'
       - '.github/workflows/_matrix-gen.yaml'
       - '.github/actions/**'
+      - 'Dockerfile'
+      # Code (deployment ID) changes
+      - 'bin.src/write_init_outputs.py'
       - 'config/**'
       - 'pipelines/**'
       - 'python/activator/**'
+      - 'python/initializer/**'
       - 'python/shared/**'
+      # Need to re-test
       - 'tests/**'
-      - 'Dockerfile'
   pull_request:
     paths:
+      # Build workflow changes
       - '.github/workflows/build-service.yml'
       - '.github/workflows/_matrix-gen.yaml'
       - '.github/actions/**'
+      - 'Dockerfile'
+      # Code (deployment ID) changes
+      - 'bin.src/write_init_outputs.py'
       - 'config/**'
       - 'pipelines/**'
       - 'python/activator/**'
+      - 'python/initializer/**'
       - 'python/shared/**'
+      # Need to re-test
       - 'tests/**'
-      - 'Dockerfile'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This PR is a fix to #256, which requires that the init-output job and the PP service be built from the same code but doesn't actually ensure that they *are* built together.