### PR TITLE
DM-49966: Support new-style coadds as Prompt Processing templates

### DIFF
--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -204,6 +204,7 @@ def make_local_cache():
             # TODO: find an API that doesn't require explicit enumeration
             "goodSeeingCoadd": template_factor * base_keep_limit,
             "deepCoadd": template_factor * base_keep_limit,
+            "template_coadd": template_factor * base_keep_limit,
             "uw_stars_20240524": refcat_factor * base_keep_limit,
             "uw_stars_20240228": refcat_factor * base_keep_limit,
             "uw_stars_20240130": refcat_factor * base_keep_limit,
@@ -1647,7 +1648,8 @@ class MiddlewareInterface:
                 raise RuntimeError from e
             graph = pipeline.to_graph()
             for dataset_type in graph.iter_overall_inputs():
-                if dataset_type[0].endswith("Coadd"):
+                # Avoid pulling in too many other sorts of coadds
+                if dataset_type[0] == "template_coadd" or dataset_type[0].endswith("Coadd"):
                     template_types.add(dataset_type[0])
         return template_types
 

--- a/tests/data/make_central_repo.sh
+++ b/tests/data/make_central_repo.sh
@@ -19,6 +19,7 @@ butler transfer-datasets embargo_or4 "$REPO" --transfer copy --register-dataset-
 butler transfer-datasets /repo/main "$REPO" --transfer copy --register-dataset-types --transfer-dimensions --dataset-type pretrainedModelPackage --collections pretrained_models/dummy
 butler transfer-datasets embargo_or4 "$REPO" --transfer copy --register-dataset-types --transfer-dimensions --dataset-type skyMap --where "skymap='ops_rehersal_prep_2k_v1'"
 butler transfer-datasets embargo_or4 "$REPO" --transfer copy --register-dataset-types --transfer-dimensions --dataset-type goodSeeingCoadd --collections LSSTComCamSim/runs/OR4_templates/w_2024_23/DM-44718/20240610T044930Z --where "instrument='LSSTComCamSim' and detector=4 and visit=7024061700046"
+# TODO: add examples of template_coadd
 butler transfer-datasets embargo_or4 "$REPO" --transfer copy --register-dataset-types --transfer-dimensions --dataset-type uw_stars_20240524 --collections refcats --where "instrument='LSSTComCamSim' and detector=4 and visit=7024061700046"
 
 # Certify non-curated calibs


### PR DESCRIPTION
This PR adds forward-compatibility with the `template_coadd` dataset type mandated by [RFC-1049](https://rubinobs.atlassian.net/browse/RFC-1049). It keeps compatibility with `deepCoadd`/`goodSeeingCoadd` until those fall out of use.

[RFC-1049]: https://rubinobs.atlassian.net/browse/RFC-1049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ