### PR TITLE
Add release notes configuration

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,7 @@
+# Configuration for automatic release notes generation
+
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - duplicate


### PR DESCRIPTION
This PR lets us mark changes (e.g., infrastructure PRs like this one) that don't affect service behavior and should not be associated with a particular release.

I've defined an `ignore-for-release` label but have not applied it to any PRs, pending approval.