### PR TITLE
DM-50071: IERS download blocked from Prompt Processing pods

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@
 !python/initializer/*.py
 !python/shared/*.py
 !pipelines
+!config/astropy.cfg
 !config/gunicorn.conf.py
 !maps
 !bin.src/write_init_outputs.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ENV PYTHONUNBUFFERED=True
 ENV APP_HOME=/app
 ENV PROMPT_PROCESSING_DIR=$APP_HOME
 ENV PYTHONPATH=$APP_HOME
+ENV XDG_CONFIG_HOME=$APP_HOME
 ARG PORT
 WORKDIR $APP_HOME
 COPY python/activator activator/
@@ -11,6 +12,7 @@ COPY python/activator activator/
 COPY python/initializer initializer/
 COPY python/shared shared/
 COPY pipelines pipelines/
+COPY config/astropy.cfg $XDG_CONFIG_HOME/astropy/
 COPY config/gunicorn.conf.py ./
 COPY maps maps/
 CMD source /opt/lsst/software/stack/loadLSST.bash \

--- a/config/astropy.cfg
+++ b/config/astropy.cfg
@@ -1,0 +1,18 @@
+[utils.data]
+
+## If False, prevents any attempt to download from Internet.
+allow_internet = False
+
+[utils.iers.iers]
+
+## Enable auto-downloading of the latest IERS-A data.  If set to False then
+## the bundled IERS-A file will be used by default (even if a newer version of
+## the IERS-A file was previously downloaded and cached). This parameter also
+## controls whether internet resources will be queried to update the leap
+## second table if the installed version is out of date. Default is True.
+auto_download = False
+
+## Maximum age (days) of predictive data before auto-downloading. See "Auto
+## refresh behavior" in astropy.utils.iers documentation for details. Default
+## is 30.
+auto_max_age = 1000

--- a/init-output-run/Dockerfile
+++ b/init-output-run/Dockerfile
@@ -4,6 +4,7 @@ ENV PYTHONUNBUFFERED=True
 ENV APP_HOME=/app
 ENV PROMPT_PROCESSING_DIR=$APP_HOME
 ENV PYTHONPATH=$APP_HOME
+ENV XDG_CONFIG_HOME=$APP_HOME
 ARG PORT
 WORKDIR $APP_HOME
 # Activator is not run by this container, but its code is needed to generate consistent version hashes.
@@ -11,6 +12,7 @@ COPY ../python/activator activator/
 COPY ../python/initializer initializer/
 COPY ../python/shared shared/
 COPY ../pipelines pipelines/
+COPY config/astropy.cfg $XDG_CONFIG_HOME/astropy/
 # Maps aren't used by this container, but they're needed to generate consistent version hashes.
 COPY maps maps/
 # #! editor doesn't run in the build workflow, but we don't need it


### PR DESCRIPTION
This PR adds a (shared) Astropy config file to the init and service pods. The config is not included in the deployment ID calculation.