### PR TITLE
DM-50299: Prompt Processing always tries to load filter-dependent calibs

### DIFF
--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -699,8 +699,14 @@ class MiddlewareInterface:
             templates = set()
         return skymaps | templates
 
-    def _get_calib_types(self):
+    def _get_calib_types(self, filter):
         """Identify the specific calib types to query.
+
+        Parameters
+        ----------
+        filter : `str`
+            Physical filter name of the upcoming visit. May be empty to indicate
+            no specific filter.
 
         Returns
         -------
@@ -745,7 +751,7 @@ class MiddlewareInterface:
         data_id = {"instrument": self.instrument.getName(), "detector": detector_id}
         if filter:
             data_id["physical_filter"] = filter
-        type_names = self._get_calib_types()
+        type_names = self._get_calib_types(filter)
 
         def query_calibs_by_date(butler, label):
             with lsst.utils.timer.time_this(_log, msg=f"Calib query ({label})", level=logging.DEBUG), \

--- a/python/shared/raw.py
+++ b/python/shared/raw.py
@@ -402,13 +402,13 @@ def get_group_id_from_oid(oid: str) -> str:
     return md.get("GROUPID", "")
 
 
-def get_raw_path(instrument, detector, group, snap, exposure_id, filter):
+def get_raw_path(instrument, detector, group, snap, exposure_id, physical_filter):
     """The path on which to store raws in the image bucket."""
     if instrument not in _LSST_CAMERA_LIST:
         return (
-            f"{instrument}/{detector}/{group}/{snap}/{exposure_id}/{filter}"
+            f"{instrument}/{detector}/{group}/{snap}/{exposure_id}/{physical_filter}"
             f"/{instrument}-{group}-{snap}"
-            f"-{exposure_id}-{filter}-{detector}.fz"
+            f"-{exposure_id}-{physical_filter}-{detector}.fz"
         )
 
     raft_sensor = _DETECTOR_FROM_INT[instrument][detector]
@@ -420,7 +420,7 @@ def get_raw_path(instrument, detector, group, snap, exposure_id, filter):
         day_obs = group[:10].replace("-", "")
         return (
             f"{instrument}/{day_obs}/{exposure_id}/"
-            f"{exposure_id}_{filter}_{detector}_{raft_sensor}.fits"
+            f"{exposure_id}_{physical_filter}_{detector}_{raft_sensor}.fits"
         )
 
     day_obs, seq_num, controller = LsstBaseTranslator.unpack_exposure_id(exposure_id)


### PR DESCRIPTION
This PR fixes a bug introduced by #249 that causes filtered calibs to be loaded unconditionally, and improves our tests and code to keep it from happening again.