### PR TITLE
Reconfigure ISR-Cal for latest obs_lsst

### DIFF
--- a/pipelines/LSSTCam/Isr-cal.yaml
+++ b/pipelines/LSSTCam/Isr-cal.yaml
@@ -13,6 +13,7 @@ tasks:
       defaultSaturationSource: CAMERAMODEL
       doApplyGains: false
       doBias: false
+      doCrosstalk: false
       doDark: false
       doDefect: false
       doDeferredCharge: false

--- a/pipelines/LSSTCam/Isr-cal.yaml
+++ b/pipelines/LSSTCam/Isr-cal.yaml
@@ -13,7 +13,6 @@ tasks:
       defaultSaturationSource: CAMERAMODEL
       doApplyGains: false
       doBias: false
-      doBootstrap: true
       doDark: false
       doDefect: false
       doDeferredCharge: false


### PR DESCRIPTION
This PR turns off an option that gives the following error: `ValueError: Cannot apply quadratic crosstalk correction with doBootstrap=True.`