### PR TITLE
DM-50423: Optimize ISR-cal for obs_lsst w_2025_16 and later

### DIFF
--- a/pipelines/LSSTCam/Isr-cal.yaml
+++ b/pipelines/LSSTCam/Isr-cal.yaml
@@ -13,6 +13,7 @@ tasks:
       defaultSaturationSource: CAMERAMODEL
       doApplyGains: false
       doBias: false
+      doBootstrap: true
       doCrosstalk: false
       doDark: false
       doDefect: false


### PR DESCRIPTION
This PR partially reverts #298, reactivating bootstrap mode for ISR-cal while keeping crosstalk correction off.