### PR TITLE
DM-50500: Prompt Processing uses incorrect definition of `SingleFrame`

### DIFF
--- a/doc/playbook.rst
+++ b/doc/playbook.rst
@@ -349,6 +349,7 @@ One raw was ingested, visit-defined, and kept in the development central repo, s
 
    apdb-cli create-sql "sqlite:///apdb.db" apdb_config.yaml
    pipetask run -b s3://rubin-pp-dev-users/central_repo_2 -i LSSTComCamSim/raw/all,LSSTComCamSim/defaults,LSSTComCamSim/templates -o u/${USER}/add-dataset-types -d "instrument='LSSTComCamSim' and exposure=7024062700235 and detector=8" -p $AP_PIPE_DIR/pipelines/LSSTComCamSim/ApPipe.yaml -c parameters:apdb_config=apdb_config.yaml -c associateApdb:doPackageAlerts=False --register-dataset-types --init-only
+   pipetask run -b s3://rubin-pp-dev-users/central_repo_2 -i LSSTComCamSim/raw/all,LSSTComCamSim/defaults,LSSTComCamSim/templates -o u/${USER}/add-dataset-types -d "instrument='LSSTComCamSim' and exposure=7024062700235 and detector=8" -p $AP_PIPE_DIR/pipelines/LSSTComCamSim/SingleFrame.yaml -c parameters:apdb_config=apdb_config.yaml --register-dataset-types --init-only
 
 .. note::
 

--- a/pipelines/HSC/SingleFrame.yaml
+++ b/pipelines/HSC/SingleFrame.yaml
@@ -1,9 +1,12 @@
 description: >-
   Single-frame pipeline for the case in which
   no templates exist, specialized for HSC
+  Unlike ap_pipe/SingleFrame.yaml, this pipeline is not standalone.
 
 imports:
   - location: $AP_PIPE_DIR/pipelines/HSC/SingleFrame.yaml
-    include:
-      - apPipeSingleFrame
-      - analyzeCalibrationMetrics
+    exclude:
+      # Run in prep_butler or Preprocessing.yaml
+      - getRegionTimeFromVisit
+      - mpSkyEphemerisQuery
+      - loadDiaCatalogs

--- a/pipelines/LATISS/SingleFrame.yaml
+++ b/pipelines/LATISS/SingleFrame.yaml
@@ -1,9 +1,12 @@
 description: >-
   Single-frame pipeline for the case in which
   no templates exist, specialized for LATISS
+  Unlike ap_pipe/SingleFrame.yaml, this pipeline is not standalone.
 
 imports:
   - location: $AP_PIPE_DIR/pipelines/LATISS/SingleFrame.yaml
-    include:
-      - apPipeSingleFrame
-      - analyzeCalibrationMetrics
+    exclude:
+      # Run in prep_butler or Preprocessing.yaml
+      - getRegionTimeFromVisit
+      - mpSkyEphemerisQuery
+      - loadDiaCatalogs

--- a/pipelines/LSSTCam-imSim/SingleFrame.yaml
+++ b/pipelines/LSSTCam-imSim/SingleFrame.yaml
@@ -1,9 +1,12 @@
 description: >-
   Single-frame pipeline for the case in which
   no templates exist, specialized for LSSTCam-imSim
+  Unlike ap_pipe/SingleFrame.yaml, this pipeline is not standalone.
 
 imports:
   - location: $AP_PIPE_DIR/pipelines/LSSTCam-imSim/SingleFrame.yaml
-    include:
-      - apPipeSingleFrame
-      - analyzeCalibrationMetrics
+    exclude:
+      # Run in prep_butler or Preprocessing.yaml
+      - getRegionTimeFromVisit
+      - mpSkyEphemerisQuery
+      - loadDiaCatalogs

--- a/pipelines/LSSTCam/SingleFrame.yaml
+++ b/pipelines/LSSTCam/SingleFrame.yaml
@@ -1,9 +1,12 @@
 description: >-
   Single-frame pipeline for the case in which
   no templates exist, specialized for LSSTCam
+  Unlike ap_pipe/SingleFrame.yaml, this pipeline is not standalone.
 
 imports:
   - location: $AP_PIPE_DIR/pipelines/LSSTCam/SingleFrame.yaml
-    include:
-      - apPipeSingleFrame
-      - analyzeCalibrationMetrics
+    exclude:
+      # Run in prep_butler or Preprocessing.yaml
+      - getRegionTimeFromVisit
+      - mpSkyEphemerisQuery
+      - loadDiaCatalogs

--- a/pipelines/LSSTComCam/SingleFrame.yaml
+++ b/pipelines/LSSTComCam/SingleFrame.yaml
@@ -1,9 +1,12 @@
 description: >-
   Single-frame pipeline for the case in which
   no templates exist, specialized for LSSTComCam
+  Unlike ap_pipe/SingleFrame.yaml, this pipeline is not standalone.
 
 imports:
   - location: $AP_PIPE_DIR/pipelines/LSSTComCam/SingleFrame.yaml
-    include:
-      - apPipeSingleFrame
-      - analyzeCalibrationMetrics
+    exclude:
+      # Run in prep_butler or Preprocessing.yaml
+      - getRegionTimeFromVisit
+      - mpSkyEphemerisQuery
+      - loadDiaCatalogs

--- a/pipelines/LSSTComCamSim/SingleFrame.yaml
+++ b/pipelines/LSSTComCamSim/SingleFrame.yaml
@@ -1,9 +1,12 @@
 description: >-
   Single-frame pipeline for the case in which
   no templates exist, specialized for LSSTComCamSim
+  Unlike ap_pipe/SingleFrame.yaml, this pipeline is not standalone.
 
 imports:
   - location: $AP_PIPE_DIR/pipelines/LSSTComCamSim/SingleFrame.yaml
-    include:
-      - apPipeSingleFrame
-      - analyzeCalibrationMetrics
+    exclude:
+      # Run in prep_butler or Preprocessing.yaml
+      - getRegionTimeFromVisit
+      - mpSkyEphemerisQuery
+      - loadDiaCatalogs


### PR DESCRIPTION
This PR corrects the definition of our `SingleFrame` pipelines to be more aligned with `ap_pipe`'s.