### PR TITLE
DM-40245: Intelligently identify datasets to preload

### DIFF
--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -605,8 +605,6 @@ class MiddlewareInterface:
                         all_datasets.update(self._export_templates(dstype, region, self.visit.filters))
                 else:
                     all_datasets.update(self._export_generic(dstype, self.visit.detector, self.visit.filters))
-            if region is not None:
-                all_datasets.update(self._export_skymap())
 
         return (all_datasets, calib_datasets)
 
@@ -702,26 +700,6 @@ class MiddlewareInterface:
         if refcats:
             _log.debug("Found %d new refcat datasets from catalog '%s'.", len(refcats), dataset_type.name)
         return refcats
-
-    def _export_skymap(self):
-        """Identify the skymap to export from the central butler.
-
-        Returns
-        -------
-        skymap : iterable [`lsst.daf.butler.DatasetRef`]
-            The datasets to be exported, after any filtering.
-        """
-        skymaps = set(_filter_datasets(
-            self.central_butler, self.butler,
-            _generic_query(["skyMap"],
-                           skymap=self.skymap_name,
-                           collections=self._collection_skymap,
-                           find_first=True,
-                           ),
-            all_callback=self._mark_dataset_usage,
-        ))
-        _log.debug("Found %d new skymap datasets.", len(skymaps))
-        return skymaps
 
     def _export_templates(self, dataset_type, region, physical_filter):
         """Identify the templates to export from the central butler.

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -606,6 +606,52 @@ class MiddlewareInterface:
                 all_datasets |= set(self._export_templates(region, self.visit.filters))
         return (all_datasets, calib_datasets)
 
+    def _get_pipeline_input_types(self, pipeline_file):
+        """Identify the dataset types needed as inputs for a pipeline.
+
+        Parameters
+        ----------
+        pipeline_file : `str`
+            The pipeline whose inputs are desired.
+
+        Returns
+        -------
+        input_types : set [`str`]
+            The types of preexisting datasets needed to run the pipeline.
+        """
+        try:
+            pipeline = self._prep_pipeline_graph(pipeline_file)
+        except FileNotFoundError as e:
+            raise RuntimeError(f"Could not find pipeline {pipeline_file}.") from e
+
+        task_inputs = {edge.parent_dataset_type_name
+                       for task in pipeline.tasks.values() for edge in task.iter_all_inputs()}
+        # Ignore inputs produced internally.
+        task_outputs = {edge.parent_dataset_type_name
+                        for task in pipeline.tasks.values() for edge in task.iter_all_outputs()}
+        return task_inputs - task_outputs
+
+    def _get_pipeline_output_types(self, pipeline_file):
+        """Identify the dataset types produced as outputs by a pipeline.
+
+        Parameters
+        ----------
+        pipeline_file : `str`
+            The pipeline whose inputs are desired.
+
+        Returns
+        -------
+        input_types : set [`str`]
+            The types of preexisting datasets needed to run the pipeline.
+        """
+        try:
+            pipeline = self._prep_pipeline_graph(pipeline_file)
+        except FileNotFoundError as e:
+            raise RuntimeError(f"Could not find pipeline {pipeline_file}.") from e
+
+        return {edge.parent_dataset_type_name
+                for task in pipeline.tasks.values() for edge in task.iter_all_outputs()}
+
     def _export_refcats(self, region):
         """Identify the refcats to export from the central butler.
 

--- a/tests/data/ISR.yaml
+++ b/tests/data/ISR.yaml
@@ -1,6 +1,14 @@
-description: Test pipeline consisting only of ISR.
+description: >-
+  Ultra-minimal test pipeline, designed to be runnable even if key
+  datasets like flats are missing.
 
 imports:
   - location: $PROMPT_PROCESSING_DIR/tests/data/ApPipe.yaml
     include:
       - isr
+tasks:
+  isr:
+    class: lsst.ip.isr.IsrTaskLSST
+    config:
+      # Don't need filter-dependent calibs
+      doFlat: false

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -208,8 +208,8 @@ def _filter_dataset_types(func, types):
     types : set [`str`]
         The dataset types to never return.
     """
-    def wrapper(self, pipeline_file):
-        return func(self, pipeline_file) - types
+    def wrapper(self, pipeline_file, include_optional=True):
+        return func(self, pipeline_file, include_optional) - types
     return wrapper
 
 


### PR DESCRIPTION
This PR self-consistently identifies inputs from the set of configured pipelines, though some hard-coding is still needed to handle classes of dataset types that behave differently (calibs, spatial datasets, etc.).