### PR TITLE
DM-51080: Uploaders may duplicate group IDs

### DIFF
--- a/python/tester/utils.py
+++ b/python/tester/utils.py
@@ -120,16 +120,14 @@ def get_last_group(bucket, instrument, date):
             last_number = 0
         return make_group(date, last_number)
     else:
-        preblobs = bucket.objects.filter(
+        blobs = bucket.objects.filter(
             Prefix=f"{instrument}/",
         )
-        detector = min(
-            (int(preblob.key.split("/")[1]) for preblob in preblobs), default=0
-        )
 
+        # format is instrument/detector/DDDD00NN/...
         group_prefix = make_compressed_date(date)
-        blobs = preblobs.filter(Prefix=f"{instrument}/{detector}/{group_prefix}")
-        numbers = [int(blob.key.split("/")[2][4:]) for blob in blobs]
+        numbers = [int(blob.key.split("/")[2][4:]) for blob in blobs
+                   if blob.key.split("/")[2].startswith(group_prefix)]
 
         if numbers:
             last_number = max(numbers)

--- a/tests/test_tester_utils.py
+++ b/tests/test_tester_utils.py
@@ -80,6 +80,12 @@ class TesterUtilsTest(MockTestCase):
         )
         obj = s3.Object(self.bucket_name, path)
         obj.put(Body=b'test3')
+        path = get_raw_path(
+            # Smallest HSC detector is 123
+            "HSC", 124, "11020003", 2, 30, "TestFilter"
+        )
+        obj = s3.Object(self.bucket_name, path)
+        obj.put(Body=b'test4')
 
     def tearDown(self):
         s3 = boto3.resource("s3")
@@ -112,7 +118,7 @@ class TesterUtilsTest(MockTestCase):
         bucket = s3.Bucket(self.bucket_name)
 
         last_group = get_last_group(bucket, "HSC", "20241102")
-        self.assertEqual(last_group, "11020002")
+        self.assertEqual(last_group, "11020003")
 
         # Test the case of no match
         last_group = get_last_group(bucket, "HSC", "20250101")


### PR DESCRIPTION
This PR fixes a bug in uploaders' group recognition code that sometimes caused group IDs to be reused, causing PP to import the wrong image.