### PR TITLE
DM-41738: Make Prompt Processing more robust to Butler connection failures

### DIFF
--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -42,7 +42,7 @@ import lsst.afw.cameraGeom
 import lsst.ctrl.mpexec
 from lsst.ctrl.mpexec import SeparablePipelineExecutor, SingleQuantumExecutor, MPGraphExecutor
 from lsst.daf.butler import Butler, CollectionType, DatasetType, Timespan, \
-    DataIdValueError, MissingDatasetTypeError
+    DataIdValueError, MissingDatasetTypeError, MissingCollectionError
 import lsst.dax.apdb
 import lsst.geom
 import lsst.obs.base
@@ -1847,10 +1847,11 @@ def _generic_query(dataset_types: collections.abc.Iterable[str | lsst.daf.butler
                     # explain=False because empty query result is ok here.
                     dataset_type, explain=False, with_dimension_records=True, *args, **kwargs
                 ))
-            except (DataIdValueError, MissingDatasetTypeError) as e:
+            except (DataIdValueError, MissingDatasetTypeError, MissingCollectionError) as e:
                 # Dimensions/dataset type often invalid for fresh local repo,
                 # where there are no, and never have been, any matching datasets.
-                # It *is* a problem for the central repo, but can be caught later.
+                # May have dimensions but no collections if a previous preload failed.
+                # These *are* a problem for the central repo, but can be caught later.
                 _log.debug("%s query failed with %s.", label, e)
         # Trace3 because, in many contexts, datasets is too large to print.
         _log_trace3.debug("%s: %s", label, datasets)

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -1916,7 +1916,7 @@ def _remove_run_completely(butler, run):
     """
     for chain in butler.registry.getCollectionParentChains(run):
         butler.collections.remove_from_chain(chain, [run])
-    butler.removeRuns([run], unstore=True)
+    butler.removeRuns([run])
 
 
 def _check_transfer_completion(expected, transferred, transfer_type):

--- a/python/shared/connect_utils.py
+++ b/python/shared/connect_utils.py
@@ -1,0 +1,69 @@
+# This file is part of prompt_processing.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+__all__ = ["retry"]
+
+
+import functools
+import logging
+
+
+_log = logging.getLogger("lsst." + __name__)
+_log.setLevel(logging.DEBUG)
+
+
+def retry(tries, exceptions):
+    """A decorator that retries a function/method call a fixed number of times
+    on specific exceptions.
+
+    Parameters
+    ----------
+    tries : `int`
+        The number of *total* attempts to make, must be at least 1.
+    exceptions : `type` [`BaseException`] or `tuple` [`type`, ...]
+        The exception(s) on which to retry the call. All other exceptions are
+        passed through.
+
+    Raises
+    ------
+    BaseExceptionGroup
+        Raised if all tries raised an exception from ``exceptions``. The
+        group contains the exception raised on each attempt.
+    """
+    if tries < 1:
+        raise ValueError("Can't try a function {tries} times.")
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            results = []
+            for t in range(tries):
+                try:
+                    return func(*args, **kwargs)
+                except exceptions as e:
+                    results.append(e)
+                    if t < tries-1:
+                        _log.warning("%s failed with %r, retrying.", func.__name__, e)
+                    continue
+            # Will be an ExceptionGroup if all exceptions are Exception
+            raise BaseExceptionGroup("{func.__name__} failed in {tries} tries.", results)
+        return wrapper
+    return decorator

--- a/tests/test_connect_utils.py
+++ b/tests/test_connect_utils.py
@@ -1,0 +1,62 @@
+# This file is part of prompt_processing.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+import unittest
+
+from shared.connect_utils import retry
+
+
+class ConnectionUtilsTest(unittest.TestCase):
+
+    def test_retry(self):
+        dummy = unittest.mock.Mock(__name__="function")
+        wrapped = retry(2, ValueError)(dummy)
+        wrapped("Foo", 42)
+        dummy.assert_called_once_with("Foo", 42)
+
+        dummy = unittest.mock.Mock(__name__="function", side_effect=[ValueError, True])
+        wrapped = retry(2, ValueError)(dummy)
+        wrapped()
+        self.assertEqual(dummy.call_count, 2)
+
+        dummy = unittest.mock.Mock(__name__="function", side_effect=ValueError)
+        wrapped = retry(2, ValueError)(dummy)
+        with self.assertRaises(ExceptionGroup):
+            wrapped()
+        self.assertEqual(dummy.call_count, 2)
+
+        dummy = unittest.mock.Mock(__name__="function", side_effect=[ValueError, RuntimeError, False])
+        wrapped = retry(3, ValueError)(dummy)
+        # RuntimeError does not trigger a retry
+        with self.assertRaises(RuntimeError):
+            wrapped()
+        self.assertEqual(dummy.call_count, 2)
+
+        dummy = unittest.mock.Mock(__name__="function", side_effect=[ValueError, RuntimeError, False])
+        wrapped = retry(3, (RuntimeError, ValueError))(dummy)
+        wrapped()
+        self.assertEqual(dummy.call_count, 3)
+
+        dummy = unittest.mock.Mock(__name__="function")
+        with self.assertRaises(ValueError):
+            retry(0, RuntimeError)(dummy)
+        retry(1, RuntimeError)(dummy)


### PR DESCRIPTION
This PR adds delayed retries to the major Butler operations (Butler initialization, preload, and export) to compensate for cases where the repo is overloaded. It also cleans up some vestigial code.