### PR TITLE
DM-50617: Abort Prompt Processing if camera rotation different from nextVisit

### DIFF
--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -26,6 +26,7 @@ import contextlib
 import functools
 import json
 import logging
+import math
 import os
 import signal
 import socket
@@ -753,6 +754,41 @@ def _parse_bucket_notifications(payload):
             _log.error("Invalid S3 bucket notification: %s", e)
 
 
+def _filter_exposures(exposures, visit, mwi):
+    """Check exposures against the nextVisit and remove any that aren't safe
+    to process.
+
+    Parameters
+    ----------
+    exposures : collection [`int`]
+        The exposures to filter. Must have been ingested.
+    visit : `shared.visit.FannedOutVisit`
+        The nextVisit for the exposures.
+    mwi : `activator.middleware_interface.MiddlewareInterface`
+        An interface for checking metadata against the local repo.
+
+    Returns
+    -------
+    filtered : set [`int`]
+        The exposures to process.
+    """
+    to_drop = set()
+    if visit.rotationSystem != FannedOutVisit.RotSys.NONE:
+        expected_angle = visit.get_rotation_sky()
+        for expid in exposures:
+            angle = mwi.get_observed_skyangle(expid)
+            if angle is not None and not math.isnan(angle.degree):
+                diff = (angle - expected_angle).wrap_at("180d")
+                if abs(diff).degree > 1.0:
+                    _log.warning("Exposure %d had sky rotation %.1f, expected %.1f. Discarding.".
+                                 expid, angle.degree, expected_angle.degree)
+                    to_drop.add(expid)
+            else:
+                _log.warning("Exposure %d is missing metadata. Discarding.", expid)
+                to_drop.add(expid)
+    return set(exposures) - to_drop
+
+
 def _try_export(mwi: MiddlewareInterface, exposures: set[int], log: logging.Logger) -> bool:
     """Attempt to export pipeline products, logging any failure.
 
@@ -948,6 +984,10 @@ def process_visit(expected_visit: FannedOutVisit):
             # If nimages == 0, any positive number of snaps is OK.
             if len(expid_set) < expected_visit.nimages:
                 _log.warning(f"Found {len(expid_set)} snaps, expected {expected_visit.nimages}.")
+
+            expid_set = _filter_exposures(expid_set, expected_visit, mwi)
+            if not expid_set:
+                raise RuntimeError("All images rejected as unprocessable.")
 
             with log_factory.add_context(exposures=expid_set):
                 # Got at least some snaps; run the pipeline.

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -49,6 +49,7 @@ import lsst.dax.apdb
 import lsst.geom
 import lsst.obs.base
 import lsst.pipe.base
+from lsst.pipe.base.quantum_graph_builder import QuantumGraphBuilderError
 import lsst.analysis.tools
 from lsst.analysis.tools.interfaces.datastore import SasquatchDispatcher  # Can't use fully-qualified name
 
@@ -1320,7 +1321,7 @@ class MiddlewareInterface:
                     # If this is a fresh (local) repo, then types like calexp,
                     # *Diff_diaSrcTable, etc. have not been registered.
                     qgraph.pipeline_graph.register_dataset_types(exec_butler)
-            except (FileNotFoundError, MissingDatasetTypeError):
+            except (QuantumGraphBuilderError, FileNotFoundError, MissingDatasetTypeError):
                 _log.exception(f"Building quantum graph for {pipeline_file} failed.")
                 continue
             if len(qgraph) == 0:

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -1198,6 +1198,31 @@ class MiddlewareInterface:
         _log.info("Ingested one %s with dataId=%s", result[0].datasetType.name, result[0].dataId)
         return result[0].dataId["exposure"]
 
+    def get_observed_skyangle(self, exposure: int) -> astropy.coordinates.Angle:
+        """Determine the sky rotation angle with which an image was taken.
+
+        Parameters
+        ----------
+        exposure : `int`
+            The exposure to test. Must have already been ingested into the
+            local repo.
+
+        Returns
+        -------
+        angle : `astropy.coordinates.Angle` or `None`
+            The observed rotation angle.
+        """
+        records = self.butler.query_dimension_records("exposure",
+                                                      instrument=self.instrument.getName(),
+                                                      exposure=exposure,
+                                                      )
+        if not records:
+            raise ValueError(f"Unknown exposure {exposure}.")
+        elif len(records) > 1:
+            _log.warning("Found %d records for exposure %s.", len(records), exposure)
+        raw_angle = records[0].sky_angle
+        return astropy.coordinates.Angle(raw_angle, "deg") if raw_angle is not None else raw_angle
+
     def _get_graph_executor(self, butler, factory):
         """Create a QuantumGraphExecutor suitable for Prompt Processing.
 

--- a/python/tester/upload.py
+++ b/python/tester/upload.py
@@ -304,6 +304,7 @@ def get_samples_lsst(bucket, instrument):
             raise RuntimeError(f"Unable to retrieve JSON sidecar: {sidecar}")
         with sidecar.open("r") as f:
             md = json.load(f)
+        angle_sys = FannedOutVisit.RotSys.SKY
 
         sal_index = INSTRUMENTS[instrument].sal_index
         # Use special sal_index to indicate a subset of detectors
@@ -319,6 +320,11 @@ def get_samples_lsst(bucket, instrument):
         physical_filter = md["FILTBAND"] or md["FILTER"]
         if instrument == "LATISS" and len(physical_filter) == 1:
             physical_filter = f"SDSS{physical_filter}_65mm~empty"
+        # LSSTCam currently only has lab data, no real sky angle
+        # TODO: remove when switching to on-sky data
+        if instrument == "LSSTCam":
+            angle_sys = FannedOutVisit.RotSys.NONE
+            md["ROTPA"] = 0.0
         visit = FannedOutVisit(
             instrument=instrument,
             detector=_DETECTOR_FROM_RS[instrument][m["raft_sensor"]],
@@ -328,7 +334,7 @@ def get_samples_lsst(bucket, instrument):
             coordinateSystem=FannedOutVisit.CoordSys.ICRS,
             position=[md["RA"], md["DEC"]],
             startTime=astropy.time.Time(md["DATE-BEG"], format="isot", scale="tai").unix_tai,
-            rotationSystem=FannedOutVisit.RotSys.SKY,
+            rotationSystem=angle_sys,
             cameraAngle=md["ROTPA"],
             survey="SURVEY",
             salIndex=sal_index,

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -604,6 +604,16 @@ class MiddlewareInterfaceTest(MockTestCase):
                                                              explain=False))
         self.assertEqual(datasets, [])
 
+    def test_get_observed_skyangle(self):
+        sci_exposure = int(self.next_visit.groupId)
+        eng_exposure = 42
+
+        self._prepare_run_pipeline()
+        # Test repo is designed with accurate nextVisit, so we can just use it as the oracle.
+        self.assertAlmostEqual(self.interface.get_observed_skyangle(sci_exposure),
+                               astropy.coordinates.Angle(self.next_visit.cameraAngle*u.degree))
+        self.assertIsNone(self.interface.get_observed_skyangle(eng_exposure))
+
     def _prepare_run_preprocessing(self):
         # Have to setup the data so that we can create the pipeline executor.
         self.interface.prep_butler()


### PR DESCRIPTION
This PR compares the sky rotation angles in the nextVisit message and the image header, and rejects the image for processing if they don't match. This prevents rotated visits from being partially processed, depending on the exact HTM/patch coverage involved.