### PR TITLE
DM-51134: Migrate away from Mamba in Prompt Processing build infrastructure

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -2,13 +2,11 @@ ARG PIPE_CONTAINER=ghcr.io/lsst/scipipe
 ARG STACK_TAG=d_latest
 FROM ${PIPE_CONTAINER}:${STACK_TAG}
 ENV PYTHONUNBUFFERED=True
-ARG KAFKA=python-confluent-kafka
 RUN <<EOT
   set -ex
   source /opt/lsst/software/stack/loadLSST.bash
   # Needed only for Knative support
   conda install -y flask
-  conda list ${KAFKA} | grep ${KAFKA} || conda install -y "${KAFKA}=2.4.0"
   pip install --no-input cloudevents
   pip install --no-input prometheus-client
   pip install --no-input redis

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -6,7 +6,8 @@ ARG KAFKA=python-confluent-kafka
 RUN <<EOT
   set -ex
   source /opt/lsst/software/stack/loadLSST.bash
-  conda install -y flask gunicorn
+  # Needed only for Knative support
+  conda install -y flask
   conda list ${KAFKA} | grep ${KAFKA} || conda install -y "${KAFKA}=2.4.0"
   pip install --no-input cloudevents
   pip install --no-input prometheus-client

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -6,8 +6,8 @@ ARG KAFKA=python-confluent-kafka
 RUN <<EOT
   set -ex
   source /opt/lsst/software/stack/loadLSST.bash
-  mamba install -y flask gunicorn
-  mamba list ${KAFKA} | grep ${KAFKA} || mamba install -y "${KAFKA}=2.4.0"
+  conda install -y flask gunicorn
+  conda list ${KAFKA} | grep ${KAFKA} || conda install -y "${KAFKA}=2.4.0"
   pip install --no-input cloudevents
   pip install --no-input prometheus-client
   pip install --no-input redis


### PR DESCRIPTION
This PR replaces mamba with conda and otherwise brings the base container up to date.