### PR TITLE
DM-51139: Support separate read and write butlers in Prompt Processing

### DIFF
--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -913,6 +913,7 @@ def process_visit(expected_visit: FannedOutVisit):
                 # Create a fresh MiddlewareInterface object to avoid accidental
                 # "cross-talk" between different visits.
                 mwi = MiddlewareInterface(_get_central_butler(),
+                                          _get_central_butler(),
                                           image_bucket,
                                           expected_visit,
                                           pre_pipelines,

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -295,7 +295,8 @@ class MiddlewareInterface:
         self._apdb_config = os.environ["CONFIG_APDB"]
         # Deployment/version ID -- potentially expensive to generate.
         self._deployment = runs.get_deployment(self._apdb_config)
-        self.central_butler = central_butler
+        self.read_central_butler = central_butler
+        self.write_central_butler = central_butler
         self.image_host = prefix + image_bucket
         # TODO: _download_store turns MWI into a tagged class; clean this up later
         if not self.image_host.startswith("file"):
@@ -303,7 +304,8 @@ class MiddlewareInterface:
         else:
             self._download_store = None
         # TODO: how much overhead do we pick up from going through the registry?
-        self.instrument = lsst.obs.base.Instrument.from_string(visit.instrument, central_butler.registry)
+        self.instrument = lsst.obs.base.Instrument.from_string(
+            visit.instrument, self.read_central_butler.registry)
         self.pre_pipelines = pre_pipelines
         self.main_pipelines = main_pipelines
 
@@ -381,17 +383,17 @@ class MiddlewareInterface:
         """
         # Camera is time-dependent, in principle, and may be available only
         # through a calibration collection.
-        camera_ref = self.central_butler.find_dataset(
+        camera_ref = self.read_central_butler.find_dataset(
             "camera",
             instrument=self.instrument.getName(),
             collections=self.instrument.makeCalibrationCollectionName(),
             timespan=Timespan.fromInstant(timestamp)
         )
-        self.camera = self.central_butler.get(camera_ref)
+        self.camera = self.read_central_butler.get(camera_ref)
 
         self.skymap_name = skymap
-        self.skymap = self.central_butler.get("skyMap", skymap=self.skymap_name,
-                                              collections=self._collection_skymap)
+        self.skymap = self.read_central_butler.get("skyMap", skymap=self.skymap_name,
+                                                   collections=self._collection_skymap)
 
     def _define_dimensions(self):
         """Define any dimensions that must be computed from this object's visit.
@@ -574,7 +576,7 @@ class MiddlewareInterface:
         present_types = net_types.copy()
         with lsst.utils.timer.time_this(_log, msg="prep_butler (find inputs)", level=logging.DEBUG):
             for type_name in net_types:
-                dstype = self.central_butler.registry.getDatasetType(type_name)
+                dstype = self.read_central_butler.registry.getDatasetType(type_name)
                 try:
                     if dstype.isCalibration():
                         new_calibs = self._find_calibs(dstype, self.visit.detector, self.visit.filters)
@@ -724,7 +726,7 @@ class MiddlewareInterface:
         """
         # Get shards from all refcats that overlap this region.
         refcats = set(_filter_datasets(
-                      self.central_butler, self.butler,
+                      self.read_central_butler, self.butler,
                       _generic_query([dataset_type],
                                      collections=self.instrument.makeRefCatCollectionName(),
                                      where="htm7.region OVERLAPS search_region",
@@ -764,7 +766,7 @@ class MiddlewareInterface:
                    "physical_filter": physical_filter,
                    }
         templates = set(_filter_datasets(
-            self.central_butler, self.butler,
+            self.read_central_butler, self.butler,
             _generic_query([dataset_type],
                            collections=self._collection_template,
                            data_id=data_id,
@@ -830,7 +832,7 @@ class MiddlewareInterface:
                 return datasets
 
         calibs = set(_filter_datasets(
-            self.central_butler, self.butler,
+            self.read_central_butler, self.butler,
             query_calibs_by_date,
             all_callback=self._mark_dataset_usage,
         ))
@@ -863,7 +865,7 @@ class MiddlewareInterface:
         if physical_filter:
             data_id["physical_filter"] = physical_filter
         datasets = set(_filter_datasets(
-            self.central_butler, self.butler,
+            self.read_central_butler, self.butler,
             _generic_query([dataset_type],
                            collections=self.instrument.makeUmbrellaCollectionName(),
                            data_id=data_id,
@@ -910,7 +912,8 @@ class MiddlewareInterface:
             types = self._get_init_output_types(pipeline_file)
             # Output runs are always cleared after execution, so _filter_datasets would always warn.
             # This also means the init-outputs don't need to be cached with _mark_dataset_usage.
-            datasets.update(_generic_query(types, collections=run)(self.central_butler, "source datasets"))
+            query = _generic_query(types, collections=run)
+            datasets.update(query(self.read_central_butler, "source datasets"))
         if not datasets:
             raise _MissingDatasetError("Source repo query found no matches.")
 
@@ -931,7 +934,7 @@ class MiddlewareInterface:
             The calibs to re-certify into the local repo.
         """
         with lsst.utils.timer.time_this(_log, msg="prep_butler (transfer datasets)", level=logging.DEBUG):
-            transferred = self.butler.transfer_from(self.central_butler,
+            transferred = self.butler.transfer_from(self.read_central_butler,
                                                     datasets,
                                                     transfer="copy",
                                                     skip_missing=True,
@@ -969,7 +972,7 @@ class MiddlewareInterface:
             The collection to be exported. It is usually a CHAINED collection
             and can have many children.
         """
-        src = self.central_butler.registry
+        src = self.read_central_butler.registry
         dest = self.butler.registry
 
         # Store collection chains after all children guaranteed to exist
@@ -998,9 +1001,9 @@ class MiddlewareInterface:
             certified in ``calib_collection`` in the central repo, and must
             exist in the local repo.
         """
-        collections = self.central_butler.collections
-        with self.central_butler.query() as query, \
-                self.central_butler.registry.caching_context():  # Nested loops produce lots of queries
+        collections = self.read_central_butler.collections
+        with self.read_central_butler.query() as query, \
+                self.read_central_butler.registry.caching_context():  # Nested loops produce lots of queries
             for dataset in datasets:
                 dtype = dataset.datasetType
                 result = query.where(dataset.dataId) \
@@ -1659,14 +1662,14 @@ class MiddlewareInterface:
             # so handle those manually.
             self._export_exposure_dimensions(
                 self.butler,
-                self.central_butler,
+                self.write_central_butler,
                 where="exposure in (exposure_ids)",
                 bind={"exposure_ids": exposure_ids},
                 instrument=self.instrument.getName(),
                 detector=self.visit.detector,
             )
-            transferred = self.central_butler.transfer_from(self.butler, datasets,
-                                                            transfer="copy", transfer_dimensions=False)
+            transferred = self.write_central_butler.transfer_from(
+                self.butler, datasets, transfer="copy", transfer_dimensions=False)
             _check_transfer_completion(datasets, transferred, "Uploaded")
 
         return transferred

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -230,10 +230,14 @@ class MiddlewareInterface:
 
     Parameters
     ----------
-    central_butler : `lsst.daf.butler.Butler`
+    read_butler : `lsst.daf.butler.Butler`
         Butler repo containing the calibration and other data needed for
         processing images as they are received. This butler must be created
         with the default instrument, skymap, and collections assigned.
+    write_butler : `lsst.daf.butler.Butler`
+        Butler repo to which pipeline outputs should be written. This butler
+        must be created with the default instrument and collections assigned.
+        May be the same object as ``read_butler``.
     image_bucket : `str`
         Storage bucket where images will be written to as they arrive.
         See also ``prefix``.
@@ -285,7 +289,7 @@ class MiddlewareInterface:
     #   corresponding to self.camera and self.skymap. Do not assume that
     #   self.butler is the only Butler pointing to the local repo.
 
-    def __init__(self, central_butler: Butler, image_bucket: str, visit: FannedOutVisit,
+    def __init__(self, read_butler: Butler, write_butler: Butler, image_bucket: str, visit: FannedOutVisit,
                  pre_pipelines: PipelinesConfig, main_pipelines: PipelinesConfig,
                  # TODO: encapsulate relationship between local_repo and local_cache
                  skymap: str, local_repo: str, local_cache: DatasetCache,
@@ -295,8 +299,8 @@ class MiddlewareInterface:
         self._apdb_config = os.environ["CONFIG_APDB"]
         # Deployment/version ID -- potentially expensive to generate.
         self._deployment = runs.get_deployment(self._apdb_config)
-        self.read_central_butler = central_butler
-        self.write_central_butler = central_butler
+        self.read_central_butler = read_butler
+        self.write_central_butler = write_butler
         self.image_host = prefix + image_bucket
         # TODO: _download_store turns MWI into a tagged class; clean this up later
         if not self.image_host.startswith("file"):

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -109,12 +109,7 @@ def get_central_butler(central_repo: str, instrument_class: str):
         A Butler for ``central_repo`` pre-configured to load and store
         ``instrument_name`` data.
     """
-    # TODO: how much overhead do we take on from asking the central repo about
-    # the instrument instead of handling it internally?
-    registry = Butler(central_repo).registry
-    instrument = lsst.obs.base.Instrument.from_string(instrument_class, registry)
     return Butler(central_repo,
-                  collections=[instrument.makeUmbrellaCollectionName()],
                   writeable=True,
                   inferDefaults=False,
                   )
@@ -233,10 +228,10 @@ class MiddlewareInterface:
     read_butler : `lsst.daf.butler.Butler`
         Butler repo containing the calibration and other data needed for
         processing images as they are received. This butler must be created
-        with the default instrument, skymap, and collections assigned.
+        with the default instrument and skymap assigned.
     write_butler : `lsst.daf.butler.Butler`
         Butler repo to which pipeline outputs should be written. This butler
-        must be created with the default instrument and collections assigned.
+        must be created with the default instrument assigned.
         May be the same object as ``read_butler``.
     image_bucket : `str`
         Storage bucket where images will be written to as they arrive.

--- a/python/initializer/write_init_outputs.py
+++ b/python/initializer/write_init_outputs.py
@@ -106,7 +106,7 @@ def main(args=None):
     instrument_name = os.environ["RUBIN_INSTRUMENT"]
     setup_usdf_logger(labels={"instrument": instrument_name},)
     try:
-        repo = os.environ["CALIB_REPO"]
+        repo = os.environ["CENTRAL_REPO"]
         _log.info("Preparing init-outputs for %s in %s.", instrument_name, repo)
 
         parsed = make_parser().parse_args(args)

--- a/tests/data/make_central_repo.sh
+++ b/tests/data/make_central_repo.sh
@@ -40,7 +40,7 @@ butler collection-chain "$REPO" LSSTComCamSim/defaults LSSTComCamSim/calib skyma
 # UI designed to be run from container, not command line
 export RUBIN_INSTRUMENT=LSSTComCamSim
 export TEMP_APDB=apdb.db  # Needed for persistent metadata table
-export CALIB_REPO="$REPO"
+export CENTRAL_REPO="$REPO"
 export CONFIG_APDB=foo.yaml
 export PREPROCESSING_PIPELINES_CONFIG="- survey: SURVEY
   pipelines:

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -1382,13 +1382,13 @@ class MiddlewareInterfaceWriteableTest(MockTestCase):
                                          for k, v in self.second_data_id.required.items()}
         # Dataset types defined for local Butler on pipeline run, but code
         # assumes output types already exist in central repo.
-        butler_tests.addDatasetType(self.interface.central_butler, "promptPreload_metrics",
+        butler_tests.addDatasetType(self.interface.write_central_butler, "promptPreload_metrics",
                                     {"instrument", "group", "detector"},
                                     "MetricMeasurementBundle")
-        butler_tests.addDatasetType(self.interface.central_butler, "regionTimeInfo",
+        butler_tests.addDatasetType(self.interface.write_central_butler, "regionTimeInfo",
                                     {"instrument", "group", "detector"},
                                     "RegionTimeInfo")
-        butler_tests.addDatasetType(self.interface.central_butler, "history_diaSource",
+        butler_tests.addDatasetType(self.interface.write_central_butler, "history_diaSource",
                                     {"instrument", "group", "detector"},
                                     "ArrowAstropy")
         butler_tests.addDatasetType(self.interface.butler, "history_diaSource",
@@ -1397,7 +1397,7 @@ class MiddlewareInterfaceWriteableTest(MockTestCase):
         butler_tests.addDatasetType(self.second_interface.butler, "history_diaSource",
                                     {"instrument", "group", "detector"},
                                     "ArrowAstropy")
-        butler_tests.addDatasetType(self.interface.central_butler, "calexp",
+        butler_tests.addDatasetType(self.interface.write_central_butler, "calexp",
                                     {"instrument", "visit", "detector"},
                                     "ExposureF")
         butler_tests.addDatasetType(self.interface.butler, "calexp",

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -227,12 +227,16 @@ class MiddlewareInterfaceTest(MockTestCase):
         self.data_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data")
         self.central_repo = os.path.join(self.data_dir, "central_repo")
         self.umbrella = f"{instname}/defaults"
-        self.central_butler = Butler(self.central_repo,
-                                     collections=[self.umbrella],
-                                     writeable=False,
-                                     inferDefaults=False)
+        self.read_butler = Butler(self.central_repo,
+                                  collections=[self.umbrella],
+                                  writeable=False,
+                                  inferDefaults=False)
+        self.write_butler = Butler(self.central_repo,
+                                   collections=[self.umbrella],
+                                   writeable=False,  # A safety in case the tests try to overwrite testdir
+                                   inferDefaults=False)
         self.input_data = os.path.join(self.data_dir, "input_data")
-        self.local_repo = make_local_repo(tempfile.gettempdir(), self.central_butler, instname)
+        self.local_repo = make_local_repo(tempfile.gettempdir(), self.read_butler, instname)
         self.local_cache = DatasetCache(3, {"uw_stars_20240524": 10, "template_coadd": 30})
         self.addCleanup(self.local_repo.cleanup)  # TemporaryDirectory warns on leaks
 
@@ -280,7 +284,8 @@ class MiddlewareInterfaceTest(MockTestCase):
                                          private_sndStamp=1718661900.7165175,
                                          )
         self.logger_name = "lsst.activator.middleware_interface"
-        self.interface = MiddlewareInterface(self.central_butler, self.input_data, self.next_visit,
+        self.interface = MiddlewareInterface(self.read_butler, self.write_butler,
+                                             self.input_data, self.next_visit,
                                              # Use empty preprocessing to avoid slowing down tests
                                              # with real pipelines (adds 20s)
                                              pre_pipelines_empty, pipelines, skymap_name,
@@ -525,7 +530,8 @@ class MiddlewareInterfaceTest(MockTestCase):
 
         # Second visit with everything same except group.
         second_visit = dataclasses.replace(self.next_visit, groupId=str(int(self.next_visit.groupId) + 1))
-        second_interface = MiddlewareInterface(self.central_butler, self.input_data, second_visit,
+        second_interface = MiddlewareInterface(self.read_butler, self.write_butler,
+                                               self.input_data, second_visit,
                                                pre_pipelines_empty, pipelines, skymap_name,
                                                self.local_repo.name, self.local_cache,
                                                prefix="file://")
@@ -548,7 +554,8 @@ class MiddlewareInterfaceTest(MockTestCase):
                                           position=[self.next_visit.position[0] - 0.2,
                                                     self.next_visit.position[1] - 0.1],
                                           )
-        third_interface = MiddlewareInterface(self.central_butler, self.input_data, third_visit,
+        third_interface = MiddlewareInterface(self.read_butler, self.write_butler,
+                                              self.input_data, third_visit,
                                               pre_pipelines_empty, pipelines, skymap_name,
                                               self.local_repo.name, self.local_cache,
                                               prefix="file://")
@@ -1087,7 +1094,7 @@ class MiddlewareInterfaceTest(MockTestCase):
         """Test that _filter_datasets provides the correct values.
         """
         # Much easier to create DatasetRefs with a real repo.
-        registry = self.central_butler.registry
+        registry = self.read_butler.registry
         data1 = self._make_expanded_ref(registry, "bias", {"instrument": "LSSTComCamSim", "detector": 5},
                                         "dummy")
         data2 = self._make_expanded_ref(registry, "bias", {"instrument": "LSSTComCamSim", "detector": 0},
@@ -1121,7 +1128,7 @@ class MiddlewareInterfaceTest(MockTestCase):
         destination repository.
         """
         # Much easier to create DatasetRefs with a real repo.
-        registry = self.central_butler.registry
+        registry = self.read_butler.registry
         data1 = self._make_expanded_ref(registry, "bias", {"instrument": "LSSTComCamSim", "detector": 1},
                                         "dummy")
 
@@ -1148,7 +1155,7 @@ class MiddlewareInterfaceTest(MockTestCase):
             self.assertEqual(expected, incoming)
 
         # Much easier to create DatasetRefs with a real repo.
-        registry = self.central_butler.registry
+        registry = self.read_butler.registry
         data1 = self._make_expanded_ref(registry, "bias", {"instrument": "LSSTComCamSim", "detector": 5},
                                         "dummy")
         data2 = self._make_expanded_ref(registry, "bias", {"instrument": "LSSTComCamSim", "detector": 0},
@@ -1194,7 +1201,7 @@ class MiddlewareInterfaceTest(MockTestCase):
 
     def test_generic_query(self):
         # Much easier to create DatasetRefs with a real repo.
-        registry = self.central_butler.registry
+        registry = self.read_butler.registry
         data1 = self._make_expanded_ref(registry, "bias", {"instrument": "LSSTComCamSim", "detector": 5},
                                         "dummy")
         data2 = self._make_expanded_ref(registry, "bias", {"instrument": "LSSTComCamSim", "detector": 0},
@@ -1264,17 +1271,22 @@ class MiddlewareInterfaceWriteableTest(MockTestCase):
 
     def setUp(self):
         self._create_copied_repo()
-        central_butler = Butler(self.central_repo.name,
-                                instrument=instname,
-                                skymap=skymap_name,
-                                collections=[f"{instname}/defaults"],
-                                writeable=True)
+        read_butler = Butler(self.central_repo.name,
+                             instrument=instname,
+                             skymap=skymap_name,
+                             collections=[f"{instname}/defaults"],
+                             writeable=False)
+        write_butler = Butler(self.central_repo.name,
+                              instrument=instname,
+                              skymap=skymap_name,
+                              collections=[f"{instname}/defaults"],
+                              writeable=True)
         data_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data")
         self.input_data = os.path.join(data_dir, "input_data")
 
-        local_repo = make_local_repo(tempfile.gettempdir(), central_butler, instname)
+        local_repo = make_local_repo(tempfile.gettempdir(), read_butler, instname)
         self.local_cache = DatasetCache(2, {"uw_stars_20240524": 10, "template_coadd": 30})
-        second_local_repo = make_local_repo(tempfile.gettempdir(), central_butler, instname)
+        second_local_repo = make_local_repo(tempfile.gettempdir(), read_butler, instname)
         self.second_local_cache = DatasetCache(2, {"uw_stars_20240524": 10, "template_coadd": 30})
         # TemporaryDirectory warns on leaks; addCleanup also keeps the TD from
         # getting garbage-collected.
@@ -1327,7 +1339,7 @@ class MiddlewareInterfaceWriteableTest(MockTestCase):
         self.logger_name = "lsst.activator.middleware_interface"
 
         # Populate repository.
-        self.interface = MiddlewareInterface(central_butler, self.input_data, self.next_visit,
+        self.interface = MiddlewareInterface(read_butler, write_butler, self.input_data, self.next_visit,
                                              pre_pipelines_full, pipelines, skymap_name, local_repo.name,
                                              self.local_cache,
                                              prefix="file://")
@@ -1350,7 +1362,7 @@ class MiddlewareInterfaceWriteableTest(MockTestCase):
         self.second_group_data_id = {(k if k != "exposure" else "group"): (v if k != "exposure" else str(v))
                                      for k, v in self.second_data_id.required.items()}
         self.second_interface = MiddlewareInterface(
-            central_butler, self.input_data, self.second_visit, pre_pipelines_full, pipelines,
+            read_butler, write_butler, self.input_data, self.second_visit, pre_pipelines_full, pipelines,
             skymap_name, second_local_repo.name, self.second_local_cache, prefix="file://")
         with unittest.mock.patch("activator.middleware_interface.MiddlewareInterface._run_preprocessing"):
             self.second_interface.prep_butler()
@@ -1437,13 +1449,14 @@ class MiddlewareInterfaceWriteableTest(MockTestCase):
         """Test that extra collections in the chain will not lead to MissingCollectionError
         even if they do not carry useful data.
         """
-        central_butler = Butler(self.central_repo.name, writeable=True)
-        central_butler.registry.registerCollection("emptyrun", CollectionType.RUN)
-        central_butler.collections.prepend_chain("refcats", ["emptyrun"])
+        write_butler = Butler(self.central_repo.name, writeable=True)
+        write_butler.registry.registerCollection("emptyrun", CollectionType.RUN)
+        write_butler.collections.prepend_chain("refcats", ["emptyrun"])
+        read_butler = Butler(self.central_repo.name, writeable=False)
 
         # Avoid collisions with other calls to prep_butler
-        with make_local_repo(tempfile.gettempdir(), central_butler, instname) as local_repo:
-            interface = MiddlewareInterface(central_butler, self.input_data,
+        with make_local_repo(tempfile.gettempdir(), read_butler, instname) as local_repo:
+            interface = MiddlewareInterface(read_butler, write_butler, self.input_data,
                                             dataclasses.replace(self.next_visit, groupId="42"),
                                             pre_pipelines_empty, pipelines, skymap_name, local_repo,
                                             DatasetCache(3, {"uw_stars_20240524": 10, "template_coadd": 30}),

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -228,11 +228,9 @@ class MiddlewareInterfaceTest(MockTestCase):
         self.central_repo = os.path.join(self.data_dir, "central_repo")
         self.umbrella = f"{instname}/defaults"
         self.read_butler = Butler(self.central_repo,
-                                  collections=[self.umbrella],
                                   writeable=False,
                                   inferDefaults=False)
         self.write_butler = Butler(self.central_repo,
-                                   collections=[self.umbrella],
                                    writeable=False,  # A safety in case the tests try to overwrite testdir
                                    inferDefaults=False)
         self.input_data = os.path.join(self.data_dir, "input_data")
@@ -298,9 +296,8 @@ class MiddlewareInterfaceTest(MockTestCase):
                        ]:
             # TODO: better way to test repo location?
             self.assertTrue(
-                butler.getURI("skyMap", skymap=skymap_name, run="foo", predict=True).ospath
+                butler.getURI("skyMap", skymap=skymap_name, collections=f"{instname}/defaults").ospath
                 .startswith(self.central_repo))
-            self.assertEqual(list(butler.collections.defaults), [f"{instname}/defaults"])
             self.assertTrue(butler.isWriteable())
 
     def test_make_local_repo(self):
@@ -1274,12 +1271,10 @@ class MiddlewareInterfaceWriteableTest(MockTestCase):
         read_butler = Butler(self.central_repo.name,
                              instrument=instname,
                              skymap=skymap_name,
-                             collections=[f"{instname}/defaults"],
                              writeable=False)
         write_butler = Butler(self.central_repo.name,
                               instrument=instname,
                               skymap=skymap_name,
-                              collections=[f"{instname}/defaults"],
                               writeable=True)
         data_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data")
         self.input_data = os.path.join(data_dir, "input_data")

--- a/tests/test_write_init_outputs.py
+++ b/tests/test_write_init_outputs.py
@@ -189,7 +189,7 @@ class InitOutputsTest(unittest.TestCase):
         with unittest.mock.patch.dict(os.environ, {"RUBIN_INSTRUMENT": "LSSTComCamSim",
                                                    "PREPROCESSING_PIPELINES_CONFIG": pre_pipelines,
                                                    "MAIN_PIPELINES_CONFIG": pipelines,
-                                                   "CALIB_REPO": self.repo.name,
+                                                   "CENTRAL_REPO": self.repo.name,
                                                    "CONFIG_APDB": self.config_file.name,
                                                    }), \
                 unittest.mock.patch("initializer.write_init_outputs._make_init_outputs",


### PR DESCRIPTION
This PR changes the repo configuration to use a two-tier system, with an optional read-only repo to reduce load on the write repo. It also removes the old "calib repo" terminology.