### PR TITLE
DM-49670: Add option for using a service for Butler database writes.

### DIFF
--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -56,7 +56,7 @@ from shared.visit import FannedOutVisit
 from .exception import GracefulShutdownInterrupt, IgnorableVisit, InvalidVisitError, \
     NonRetriableError, RetriableError
 from .middleware_interface import get_central_butler, \
-    make_local_repo, make_local_cache, MiddlewareInterface
+    make_local_repo, make_local_cache, MiddlewareInterface, ButlerWriter, DirectButlerWriter
 from .repo_tracker import LocalRepoTracker
 
 # Platform that prompt processing will run on
@@ -186,6 +186,10 @@ def _get_read_butler():
         # Don't initialize an extra Butler from scratch
         return _get_write_butler()
 
+@functools.cache
+def _get_butler_writer() -> ButlerWriter:
+    """Lazy initialization of Butler writer."""
+    return DirectButlerWriter(_get_write_butler())
 
 @functools.cache
 def _get_local_repo():
@@ -458,7 +462,7 @@ def create_app():
         _get_consumer()
         _get_storage_client()
         _get_read_butler()
-        _get_write_butler()
+        _get_butler_writer()
         _get_local_repo()
 
         app = flask.Flask(__name__)
@@ -506,7 +510,7 @@ def keda_start():
         _get_consumer()
         _get_storage_client()
         _get_read_butler()
-        _get_write_butler()
+        _get_butler_writer()
         _get_local_repo()
 
         redis_session = RedisStreamSession(
@@ -929,7 +933,7 @@ def process_visit(expected_visit: FannedOutVisit):
                 # Create a fresh MiddlewareInterface object to avoid accidental
                 # "cross-talk" between different visits.
                 mwi = MiddlewareInterface(_get_read_butler(),
-                                          _get_write_butler(),
+                                          _get_butler_writer(),
                                           image_bucket,
                                           expected_visit,
                                           pre_pipelines,

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -57,6 +57,7 @@ from .exception import GracefulShutdownInterrupt, IgnorableVisit, InvalidVisitEr
     NonRetriableError, RetriableError
 from .middleware_interface import get_central_butler, \
     make_local_repo, make_local_cache, MiddlewareInterface, ButlerWriter, DirectButlerWriter
+from .kafka_butler_writer import KafkaButlerWriter
 from .repo_tracker import LocalRepoTracker
 
 # Platform that prompt processing will run on
@@ -87,6 +88,16 @@ kafka_group_id = str(uuid.uuid4())
 visit_expire = float(os.environ.get("MESSAGE_EXPIRATION", 3600))
 # The topic on which to listen to updates to image_bucket
 bucket_topic = os.environ.get("BUCKET_TOPIC", "rubin-prompt-processing")
+# Topic used to transfer output datasets to the central repository.
+# Used if USE_KAFKA_OUTPUT_WRITER is set to '1'.
+output_topic = os.environ.get("OUTPUT_TOPIC", "rubin-prompt-processing-butler-output")
+# URI to the path where output datasets will be written when using the Kafka
+# writer to transfer outputs to the central Butler repository.
+# This will generally be in the same S3 bucket used by the central Butler.
+file_output_path = os.environ.get("OUTPUT_FILE_PATH")
+# If '1', sends outputs to a service for transfer into the central Butler
+# repository instead of writing to the database directly.
+use_kafka_output_writer = os.environ.get("USE_KAFKA_OUTPUT_WRITER", "0") == "1"
 # Offset for Kafka bucket notification.
 bucket_notification_kafka_offset_reset = os.environ.get("BUCKET_NOTIFICATION_KAFKA_OFFSET_RESET", "latest")
 # Max requests to handle before restarting. 0 means no limit.
@@ -160,6 +171,12 @@ def _get_consumer():
         "auto.offset.reset": bucket_notification_kafka_offset_reset,
     })
 
+@functools.cache
+def _get_producer():
+    """Lazy initialization of shared Kafka Producer."""
+    return kafka.Producer({
+        "bootstrap.servers": kafka_cluster,
+    })
 
 @functools.cache
 def _get_storage_client():
@@ -189,7 +206,13 @@ def _get_read_butler():
 @functools.cache
 def _get_butler_writer() -> ButlerWriter:
     """Lazy initialization of Butler writer."""
-    return DirectButlerWriter(_get_write_butler())
+    assert file_output_path is not None
+    if use_kafka_output_writer:
+        return KafkaButlerWriter(
+            _get_producer(), output_topic=output_topic, file_output_path=file_output_path
+        )
+    else:
+        return DirectButlerWriter(_get_write_butler())
 
 @functools.cache
 def _get_local_repo():

--- a/python/activator/kafka_butler_writer.py
+++ b/python/activator/kafka_butler_writer.py
@@ -1,0 +1,79 @@
+# This file is part of prompt_processing.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from __future__ import annotations
+
+from datetime import date
+from typing import Literal
+from uuid import uuid4
+
+from confluent_kafka import Producer
+import pydantic
+
+from lsst.daf.butler import (
+    Butler,
+    DatasetRef,
+    DimensionRecord,
+    SerializedDatasetType,
+    SerializedDimensionRecord,
+    SerializedFileDataset,
+)
+from lsst.resources import ResourcePath
+
+
+class KafkaButlerWriter:
+    def __init__(self, producer: Producer, *, output_topic: str, file_output_path: str) -> None:
+        self._producer = producer
+        self._output_topic = output_topic
+        self._file_output_path = ResourcePath(file_output_path, forceDirectory=True)
+
+    def transfer_outputs(self, local_butler: Butler, dimension_records: list[DimensionRecord], datasets: list[DatasetRef]) -> None:
+        # Create a subdirectory in the output root distinct to this processing
+        # run.
+        date_string = date.today().strftime("%Y-%m-%d")
+        subdirectory = f"{date_string}/{uuid4()}/"
+        output_directory = self._file_output_path.join(subdirectory, forceDirectory=True)
+
+        # Copy files to the output directory, and retrieve metadata required to
+        # ingest them into the central Butler.
+        file_datasets = local_butler._datastore.export(datasets, directory=output_directory, transfer="copy")
+
+        # Serialize Butler data as a JSON string.
+        dataset_types = {dataset.datasetType for dataset in datasets}
+        event = PromptProcessingOutputEvent(
+            type="pp-output",
+            dimension_records=[record.to_simple() for record in dimension_records],
+            datasets=[dataset.to_simple() for dataset in file_datasets],
+            dataset_types=[dt.to_simple() for dt in dataset_types],
+            root_directory=subdirectory,
+        )
+        message = event.model_dump_json()
+
+        self._producer.produce(self._output_topic, message)
+        self._producer.flush()
+
+
+class PromptProcessingOutputEvent(pydantic.BaseModel):
+    type: Literal["pp-output"]
+    root_directory: str
+    dimension_records: list[SerializedDimensionRecord]
+    dataset_types: list[SerializedDatasetType]
+    datasets: list[SerializedFileDataset]

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -44,7 +44,7 @@ import lsst.afw.cameraGeom
 import lsst.ctrl.mpexec
 from lsst.ctrl.mpexec import SeparablePipelineExecutor, SingleQuantumExecutor, MPGraphExecutor
 from lsst.daf.butler import Butler, CollectionType, DatasetType, Timespan, \
-    DataIdValueError, MissingDatasetTypeError, MissingCollectionError
+    DataIdValueError, DimensionRecord, MissingDatasetTypeError, MissingCollectionError
 import lsst.dax.apdb
 import lsst.geom
 import lsst.obs.base
@@ -1655,20 +1655,23 @@ class MiddlewareInterface:
             except lsst.daf.butler.registry.DataIdError as e:
                 raise ValueError("Invalid visit or exposures.") from e
 
-        with lsst.utils.timer.time_this(_log, msg="export_outputs (transfer)", level=logging.DEBUG):
             # Transfer dimensions created by ingest in case it was never done in
             # central repo (which is normal for dev).
             # Transferring governor dimensions in parallel can cause deadlocks in
             # central registry. We need to transfer our exposure/visit dimensions,
             # so handle those manually.
-            self._export_exposure_dimensions(
+            dimension_records = self._export_exposure_dimensions(
                 self.butler,
-                self.write_central_butler,
                 where="exposure in (exposure_ids)",
                 bind={"exposure_ids": exposure_ids},
                 instrument=self.instrument.getName(),
                 detector=self.visit.detector,
             )
+
+        with lsst.utils.timer.time_this(_log, msg="export_outputs (transfer)", level=logging.DEBUG):
+            for dimension, records in dimension_records.items():
+                # If records don't match, this is not an error, and central takes precedence.
+                self.write_central_butler.registry.insertDimensionData(dimension, *records, skip_existing=True)
             transferred = self.write_central_butler.transfer_from(
                 self.butler, datasets, transfer="copy", transfer_dimensions=False)
             _check_transfer_completion(datasets, transferred, "Uploaded")
@@ -1676,8 +1679,9 @@ class MiddlewareInterface:
         return transferred
 
     @staticmethod
-    def _export_exposure_dimensions(src_butler, dest_butler, **kwargs):
-        """Transfer dimensions generated from an exposure to the central repo.
+    def _export_exposure_dimensions(src_butler, **kwargs) -> dict[str, list[DimensionRecord]]:
+        """Retrieve dimension records generated from an exposure that need to
+        be transferred to the central repo.
 
         In many cases the exposure records will already exist in the central
         repo, but this is not guaranteed (especially in dev environments).
@@ -1688,12 +1692,15 @@ class MiddlewareInterface:
         ----------
         src_butler : `lsst.daf.butler.Butler`
             The butler from which to transfer dimension records.
-        dest_butler : `lsst.daf.butler.Butler`
-            The butler to which to transfer records.
         **kwargs
             Any data ID parameters to select specific records. They have the
             same meanings as the parameters of
             `lsst.daf.butler.Butler.query_dimension_records`.
+
+        Returns
+        -------
+        dimension_records : `dict` [ `str` , `list` [ `lsst.daf.butler.DimensionRecord` ] ]
+            Dictionary from dimension name to list of dimension records for that dimension.
         """
         core_dimensions = ["group",
                            "day_obs",
@@ -1711,8 +1718,7 @@ class MiddlewareInterface:
 
         for dimension in sorted_dimensions:
             records = src_butler.query_dimension_records(dimension, explain=False, **kwargs)
-            # If records don't match, this is not an error, and central takes precedence.
-            dest_butler.registry.insertDimensionData(dimension, *records, skip_existing=True)
+        return records
 
     def _query_datasets_by_storage_class(self, butler, exposure_ids, collections, storage_class):
         """Identify all datasets with a particular storage class, regardless of

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -1614,7 +1614,7 @@ class MiddlewareInterface:
 
     @connect.retry(2, DATASTORE_EXCEPTIONS, wait=repo_retry)
     def _export_subset(self, exposure_ids: set[int],
-                       dataset_types: typing.Any, in_collections: typing.Any) -> None:
+                       dataset_types: typing.Any, in_collections: typing.Any) -> list[DatasetRef]:
         """Copy datasets associated with a processing run back to the
         central Butler.
 

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -43,7 +43,7 @@ import lsst.sphgeom
 import lsst.afw.cameraGeom
 import lsst.ctrl.mpexec
 from lsst.ctrl.mpexec import SeparablePipelineExecutor, SingleQuantumExecutor, MPGraphExecutor
-from lsst.daf.butler import Butler, CollectionType, DatasetType, Timespan, \
+from lsst.daf.butler import Butler, CollectionType, DatasetType, DatasetRef, Timespan, \
     DataIdValueError, DimensionRecord, MissingDatasetTypeError, MissingCollectionError
 import lsst.dax.apdb
 import lsst.geom
@@ -206,6 +206,61 @@ def _get_sasquatch_dispatcher():
     namespace = os.environ.get("DAF_BUTLER_SASQUATCH_NAMESPACE", "lsst.prompt")
     return SasquatchDispatcher(url=url, token=token, namespace=namespace)
 
+GroupedDimensionRecords: typing.TypeAlias = dict[str, list[DimensionRecord]]
+"""Dictionary from dimension name to list of dimension records for that
+dimension.
+"""
+
+class ButlerWriter(typing.Protocol):
+    """Interface defining functions for writing output datasets back to the central
+    Butler repository.
+    """
+
+    def transfer_outputs(
+        self, local_butler: Butler, dimension_records: GroupedDimensionRecords, datasets: list[DatasetRef]
+    ) -> list[DatasetRef]:
+        """Transfer outputs back to the central repository.
+
+        Parameters
+        ----------
+        local_butler : `lsst.daf.butler.Butler`
+            Local Butler repository from which output datasets will be
+            transferred.
+        dimension_records : `activator.middleware_interface.GroupedDimensionRecords`
+            Dimension records to write to the central Butler repository.
+        datasets : `list` [ `lsst.daf.butler.DatasetRef` ]
+            Output datasets to transfer to the central Butler repository.
+
+        Returns
+        -------
+        transferred : `list` [ `DatasetRef` ]
+            List of datasets actually transferred.
+        """
+
+class DirectButlerWriter(ButlerWriter):
+    def __init__(self, central_butler: Butler) -> None:
+        """
+        Writes Butler outputs back to the central repository by connecting
+        directly to the Butler database.
+
+        Parameters
+        ----------
+        central_butler : `lsst.daf.butler.Butler`
+            Butler repo to which pipeline outputs should be written. This
+            butler must be created with the default instrument assigned.
+        """
+        self._central_butler = central_butler
+
+    def transfer_outputs(
+        self, local_butler: Butler, dimension_records: GroupedDimensionRecords, datasets: list[DatasetRef]
+    ) -> list[DatasetRef]:
+        for dimension, records in dimension_records.items():
+            # If records don't match, this is not an error, and central takes precedence.
+            self._central_butler.registry.insertDimensionData(dimension, *records, skip_existing=True)
+
+        return self._central_butler.transfer_from(
+            local_butler, datasets, transfer="copy", transfer_dimensions=False)
+
 
 class MiddlewareInterface:
     """Interface layer between the Butler middleware and the prompt processing
@@ -231,9 +286,9 @@ class MiddlewareInterface:
         Butler repo containing the calibration and other data needed for
         processing images as they are received. This butler must be created
         with the default instrument and skymap assigned.
-    write_butler : `lsst.daf.butler.Butler`
-        Butler repo to which pipeline outputs should be written. This butler
-        must be created with the default instrument assigned.
+    butler_writer : `activator.middleware_interface.ButlerWriter`
+        Object that will be used to write the pipeline outputs back to the 
+        central Butler repository.
         May be the same object as ``read_butler``.
     image_bucket : `str`
         Storage bucket where images will be written to as they arrive.
@@ -286,7 +341,7 @@ class MiddlewareInterface:
     #   corresponding to self.camera and self.skymap. Do not assume that
     #   self.butler is the only Butler pointing to the local repo.
 
-    def __init__(self, read_butler: Butler, write_butler: Butler, image_bucket: str, visit: FannedOutVisit,
+    def __init__(self, read_butler: Butler, butler_writer: ButlerWriter, image_bucket: str, visit: FannedOutVisit,
                  pre_pipelines: PipelinesConfig, main_pipelines: PipelinesConfig,
                  # TODO: encapsulate relationship between local_repo and local_cache
                  skymap: str, local_repo: str, local_cache: DatasetCache,
@@ -297,7 +352,7 @@ class MiddlewareInterface:
         # Deployment/version ID -- potentially expensive to generate.
         self._deployment = runs.get_deployment(self._apdb_config)
         self.read_central_butler = read_butler
-        self.write_central_butler = write_butler
+        self._butler_writer = butler_writer
         self.image_host = prefix + image_bucket
         # TODO: _download_store turns MWI into a tagged class; clean this up later
         if not self.image_host.startswith("file"):
@@ -1669,17 +1724,13 @@ class MiddlewareInterface:
             )
 
         with lsst.utils.timer.time_this(_log, msg="export_outputs (transfer)", level=logging.DEBUG):
-            for dimension, records in dimension_records.items():
-                # If records don't match, this is not an error, and central takes precedence.
-                self.write_central_butler.registry.insertDimensionData(dimension, *records, skip_existing=True)
-            transferred = self.write_central_butler.transfer_from(
-                self.butler, datasets, transfer="copy", transfer_dimensions=False)
+            transferred = self._butler_writer.transfer_outputs(self.butler, dimension_records, list(datasets))
             _check_transfer_completion(datasets, transferred, "Uploaded")
 
         return transferred
 
     @staticmethod
-    def _export_exposure_dimensions(src_butler, **kwargs) -> dict[str, list[DimensionRecord]]:
+    def _export_exposure_dimensions(src_butler, **kwargs) -> GroupedDimensionRecords:
         """Retrieve dimension records generated from an exposure that need to
         be transferred to the central repo.
 


### PR DESCRIPTION
Added environment variables `USE_KAFKA_OUTPUT_WRITER`, `OUTPUT_TOPIC`, and `OUTPUT_FILE_PATH` to control how Butler outputs are written back to the central repository.  When `USE_KAFKA_OUTPUT_WRITER=1`, writes to the central Butler database will be done indirectly by sending a Kafka message to a service, instead of connecting directly from Prompt Processing.
