### PR TITLE
DM-51747: Fatal typo in Prompt Processing rotation checker

### DIFF
--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -803,7 +803,7 @@ def _filter_exposures(exposures, visit, mwi):
             if angle is not None and not math.isnan(angle.degree):
                 diff = (angle - expected_angle).wrap_at("180d")
                 if abs(diff).degree > 1.0:
-                    _log.warning("Exposure %d had sky rotation %.1f, expected %.1f. Discarding.".
+                    _log.warning("Exposure %d had sky rotation %.1f, expected %.1f. Discarding.",
                                  expid, angle.degree, expected_angle.degree)
                     to_drop.add(expid)
             else:


### PR DESCRIPTION
This PR fixes a bug that only appears when an exposure doesn't arrive with the expected rotation angle.