### PR TITLE
DM-52180: Write files to datastore for Butler writer service

### DIFF
--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -109,10 +109,6 @@ if use_kafka_butler_writer:
     butler_writer_kafka_password = os.environ["BUTLER_WRITER_KAFKA_PASSWORD"]
     # Topic used to transfer output datasets to the central repository.
     butler_writer_kafka_topic = os.environ["BUTLER_WRITER_KAFKA_TOPIC"]
-    # URI to the path where output datasets will be written when using the Kafka
-    # writer to transfer outputs to the central Butler repository.
-    # This will generally be in the same S3 bucket used by the central Butler.
-    butler_writer_file_output_path = os.environ["BUTLER_WRITER_FILE_OUTPUT_PATH"]
 
 # Conditionally load keda environment variables
 if platform == "keda":
@@ -226,7 +222,7 @@ def _get_butler_writer() -> ButlerWriter:
         return KafkaButlerWriter(
             _get_producer(),
             output_topic=butler_writer_kafka_topic,
-            file_output_path=butler_writer_file_output_path
+            output_repo=write_repo
         )
     else:
         return DirectButlerWriter(_get_write_butler())

--- a/tests/test_kafka_butler_writer.py
+++ b/tests/test_kafka_butler_writer.py
@@ -58,11 +58,12 @@ class KafkaButlerWriterTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as output_directory:
             topic = "topic-name"
             # Simulate a transfer, writing the datasets into a temporary
-            # directory.
+            # Butler repository.
+            Butler.makeRepo(output_directory)
             writer = KafkaButlerWriter(
                 producer=kafka_producer_mock,
                 output_topic=topic,
-                file_output_path=output_directory
+                output_repo=output_directory
             )
             datasets_transferred = writer.transfer_outputs(butler, dimension_records, datasets)
 
@@ -76,5 +77,5 @@ class KafkaButlerWriterTest(unittest.TestCase):
             self.assertEqual(len(model.dimension_records), num_dimension_records)
 
             # Check that datasets were written to the output directory.
-            output_files = [path for path in Path(output_directory).rglob("*") if path.is_file()]
+            output_files = list(Path(output_directory).rglob("*.fits"))
             self.assertEqual(len(output_files), num_datasets)


### PR DESCRIPTION
When using the Kafka Butler writer service to transfer outputs to the central repository, we now write files directly to their final location in the Butler datastore.  This avoids wasting S3 bandwidth from the writer service making a copy of the files.

This requires a new `daf_butler` function that is only available starting from the August 29th daily, and release 2.0.1 of the butler writer service.  This new version is not backwards-compatible with the previous 1.0.0 version of the writer service.