### PR TITLE
DM-47743: Factor local repo management out of MiddlewareInterface

### DIFF
--- a/bin.src/make_export.py
+++ b/bin.src/make_export.py
@@ -29,6 +29,7 @@ file for importing to the test central prompt processing repository.
 
 
 import argparse
+import collections.abc
 import logging
 import sys
 import tempfile
@@ -37,7 +38,7 @@ import yaml
 import lsst.daf.butler as daf_butler
 from lsst.utils.timer import time_this
 
-from activator.middleware_interface import _filter_datasets, _generic_query
+from activator.middleware_interface import _filter_datasets
 
 
 def _make_parser():
@@ -132,7 +133,8 @@ def _export_for_copy(butler, target_butler, wants):
                         all_types, collections_info
                     )
                 records = _filter_datasets(
-                    butler, target_butler, _generic_query(dataset_types, **selection)
+                    butler, target_butler,
+                    lambda b, _: _query_no_undefined(b, dataset_types, **selection)
                 )
                 contents.saveDatasets(records)
 
@@ -147,6 +149,42 @@ def _export_for_copy(butler, target_butler, wants):
                     except daf_butler.registry.MissingCollectionError:
                         # MissingCollectionError is raised if the collection does not exist in target_butler.
                         contents.saveCollection(collection)
+
+
+def _query_no_undefined(butler: daf_butler.Butler,
+                        dataset_types: collections.abc.Iterable[str | daf_butler.DatasetType],
+                        *args,
+                        **kwargs) -> collections.abc.Iterable[daf_butler.DatasetRef]:
+    """Query a Butler, treating missing data IDs, dataset types, etc. as
+    empty results.
+
+    Parameters
+    ----------
+    butler : `lsst.daf.butler.Butler`
+        The Butler to query.
+    dataset_types : iterable [`str` | `lsst.daf.butler.DatasetType`]
+        Iterable of dataset type object or name to search for.
+    *args, **kwargs
+        Parameters for describing the dataset query. They have the same
+        meanings as the parameters of `lsst.daf.butler.query_datasets`.
+
+    Returns
+    -------
+    datasets : iterable [`lsst.daf.butler.DatasetRef`]
+        The datasets found by the query. All dataset refs are fully expanded.
+    """
+    datasets = set()
+    for dataset_type in dataset_types:
+        try:
+            datasets |= set(butler.query_datasets(
+                # explain=False because empty query result is ok here.
+                dataset_type, explain=False, with_dimension_records=True, *args, **kwargs
+            ))
+        except (daf_butler.DataIdValueError,
+                daf_butler.MissingDatasetTypeError,
+                daf_butler.MissingCollectionError) as e:
+            logging.debug("query failed with %s.", e)
+    return datasets
 
 
 if __name__ == "__main__":

--- a/bin.src/make_export.py
+++ b/bin.src/make_export.py
@@ -38,8 +38,6 @@ import yaml
 import lsst.daf.butler as daf_butler
 from lsst.utils.timer import time_this
 
-from activator.middleware_interface import _filter_datasets
-
 
 def _make_parser():
     parser = argparse.ArgumentParser()
@@ -132,11 +130,14 @@ def _export_for_copy(butler, target_butler, wants):
                     dataset_types = butler.collections._filter_dataset_types(
                         all_types, collections_info
                     )
-                records = _filter_datasets(
-                    butler, target_butler,
-                    lambda b, _: _query_no_undefined(b, dataset_types, **selection)
-                )
-                contents.saveDatasets(records)
+                all_records = set(_query_no_undefined(butler, dataset_types, **selection))
+                if not all_records:
+                    raise RuntimeError("Query found no matches in source repo.")
+                target_records = set(_query_no_undefined(target_butler, dataset_types, **selection))
+                missing = all_records - target_records
+                logging.debug("Found %d matching datasets. %d present in target, %d to export.",
+                              len(all_records), len(all_records & target_records), len(missing))
+                contents.saveDatasets(missing)
 
         # Save selected collections and chains
         if "collections" in wants:

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -29,7 +29,6 @@ import logging
 import math
 import os
 import signal
-import tempfile
 import time
 import uuid
 import yaml
@@ -50,8 +49,9 @@ from shared.raw import (
 from shared.visit import FannedOutVisit
 from .exception import GracefulShutdownInterrupt, TimeoutInterrupt, IgnorableVisit, \
     NonRetriableError, RetriableError
+from .local_repo import LocalRepo
 from .middleware_interface import get_central_butler, \
-    make_local_repo, make_local_cache, MiddlewareInterface, ButlerWriter, DirectButlerWriter
+    MiddlewareInterface, ButlerWriter, DirectButlerWriter
 from .kafka_butler_writer import KafkaButlerWriter
 from .repo_tracker import LocalRepoTracker
 from .startstop import ServiceManager
@@ -194,26 +194,19 @@ def _get_butler_writer() -> ButlerWriter:
 
 @ServiceManager.check_on_init
 @functools.cache
-@ServiceManager.clean_on_exit(tempfile.TemporaryDirectory.cleanup)
+@ServiceManager.clean_on_exit(LocalRepo.close)
 def _get_local_repo():
     """Lazy initialization of a new local repo.
 
     Returns
     -------
-    repo : `tempfile.TemporaryDirectory`
-        The directory containing the repo, to be removed when the
-        process exits.
+    repo : `activator.local_repo.LocalRepo`
+        An object that represents and manages the repo.
     """
-    repo = make_local_repo(local_repo_space, _get_read_butler(), instrument_name)
+    repo = LocalRepo(local_repo_space, _get_read_butler(), instrument_name)
     tracker = LocalRepoTracker.get()
-    tracker.register(os.getpid(), repo.name)
+    tracker.register(os.getpid(), repo.repo_location)
     return repo
-
-
-@functools.cache
-def _get_local_cache():
-    """Lazy initialization of local repo dataset cache."""
-    return make_local_cache()
 
 
 def time_since(start_time):
@@ -609,10 +602,8 @@ def _process_visit_or_cancel(expected_visit: FannedOutVisit):
                                       pre_pipelines,
                                       main_pipelines,
                                       skymap,
-                                      _get_local_repo().name,
-                                      _get_local_cache())
-            # TODO: remove on DM-47743
-            cleanups.callback(mwi.close)
+                                      _get_local_repo(),
+                                      )
             if not mwi.get_main_pipeline_files():
                 raise IgnorableVisit(f"No pipeline configured for {expected_visit}.")
             # TODO: pipeline execution requires a clean run until DM-38041.

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -591,6 +591,9 @@ def _process_visit_or_cancel(expected_visit: FannedOutVisit):
             f"Expected {instrument_name}, received {expected_visit.instrument}."
 
         try:
+            # TODO: pipeline execution requires a clean run until DM-38041.
+            cleanups.callback(_get_local_repo().clean)
+
             expid_set = set()
 
             # Create a fresh MiddlewareInterface object to avoid accidental
@@ -606,8 +609,6 @@ def _process_visit_or_cancel(expected_visit: FannedOutVisit):
                                       )
             if not mwi.get_main_pipeline_files():
                 raise IgnorableVisit(f"No pipeline configured for {expected_visit}.")
-            # TODO: pipeline execution requires a clean run until DM-38041.
-            cleanups.callback(mwi.clean_local_repo)
             # Copy calibrations for this detector/visit
             mwi.prep_butler()
 

--- a/python/activator/activator.py
+++ b/python/activator/activator.py
@@ -222,7 +222,7 @@ def time_since(start_time):
     Parameters
     ----------
     start_time : `float`
-        Time since a reference point, in seconds since Unix epoch.
+        A reference point, in seconds since Unix epoch.
 
     Returns
     -------

--- a/python/activator/local_repo.py
+++ b/python/activator/local_repo.py
@@ -1,0 +1,359 @@
+# This file is part of prompt_processing.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+__all__ = ["LocalRepo"]
+
+
+import collections.abc
+import logging
+import os
+import tempfile
+import warnings
+
+import sqlalchemy.exc
+
+import lsst.daf.butler as daf_butler
+import lsst.obs.base as obs_base
+import lsst.utils.timer
+
+import shared.connect_utils as connect
+from .caching import DatasetCache
+from .mw_retries import repo_retry, DATASTORE_EXCEPTIONS
+
+
+_log = logging.getLogger("lsst." + __name__)
+_log.setLevel(logging.DEBUG)
+# See https://developer.lsst.io/stack/logging.html#logger-trace-verbosity
+_log_trace = logging.getLogger("TRACE1.lsst." + __name__)
+_log_trace.setLevel(logging.CRITICAL)  # Turn off by default.
+
+
+# TODO: rationalize config options on DM-52695
+# The number of calib datasets to keep, including the current run.
+base_keep_limit = int(os.environ.get("LOCAL_REPO_CACHE_SIZE", 3))
+# An optional file with local butler repo config overrides.
+local_repo_config = os.environ.get("LOCAL_REPO_CONFIG", None)
+
+
+class LocalRepo:
+    """A worker-local Butler repository and all state needed to manage it.
+
+    This class is responsible for creating/cleaning up the local repository, as
+    well as for maintaining data integrity. Science-related decisions such as
+    populating the repository with pipeline inputs are the responsibility of
+    this class's clients.
+
+    This object guarantees that the repository exists (until it is closed), and
+    that it contains standard collections and the registration of
+    ``instrument``.
+
+    Parameters
+    ----------
+    local_storage : `str`
+        A path to a space where this class can create a local
+        Butler repo.
+    central_butler : `lsst.daf.butler.Butler`
+        Butler repo containing instrument and skymap definitions.
+    instrument : `str`
+        Name of the instrument taking the data, for populating
+        butler collections and dataIds. May be either the fully qualified class
+        name or the short name. Examples: "LsstCam", "lsst.obs.lsst.LsstCam".
+    """
+
+    @property
+    def butler(self):
+        """A writeable Butler giving access to this repository
+        (`lsst.daf.butler.Butler`).
+
+        The Butler defaults to the "defaults" chained collection, which
+        contains all pipeline inputs.
+        """
+        if self._closed:
+            raise RuntimeError("Local repo has been cleaned up, no Butler operations are possible.")
+        return self._butler
+
+    @property
+    def repo_location(self):
+        """A file path (not a URI) identifying the repository.
+
+        This path should only be used to handle registration of the repository
+        with `~activator.repo_tracker.LocalRepoTracker`. All other repository
+        operations should be done through this class or the `butler` property.
+        """
+        if self._closed:
+            raise RuntimeError("Local repo has been cleaned up and no longer exists.")
+        return self._repo.name
+
+    def __init__(self, local_storage: str, central_butler: daf_butler.Butler, instrument: str):
+        self._closed = False
+        try:
+            self._instrument = obs_base.Instrument.from_string(instrument, central_butler.registry)
+        except RuntimeError as e:
+            raise ValueError(f"Invalid instrument {instrument!r}") from e
+        self._repo = self._make_local_repo(local_storage, central_butler, self._instrument)
+        self._butler = self._make_local_butler(self._repo.name, self._instrument)
+        self._cache = self._make_local_cache()
+
+    @classmethod
+    def _make_local_repo(cls,
+                         local_storage: str,
+                         central_butler: daf_butler.Butler,
+                         instrument: obs_base.Instrument,
+                         ) -> tempfile.TemporaryDirectory:
+        """Create and configure a new local repository.
+
+        The repository is represented by a temporary directory object, which can be
+        used to manage its lifetime.
+
+        Parameters
+        ----------
+        local_storage : `str`
+            A path to a space where this function can create a local
+            Butler repo.
+        central_butler : `lsst.daf.butler.Butler`
+            Butler repo containing instrument and skymap definitions.
+        instrument : `lsst.obs.base.Instrument`
+            The instrument taking the data, for populating butler collections
+            and dataIds.
+
+        Returns
+        -------
+        repo_dir : `tempfile.TemporaryDirectory`
+            An object pointing to the local repo location.
+        """
+        dimension_config = central_butler.dimensions.dimensionConfig
+        repo_dir = tempfile.TemporaryDirectory(dir=local_storage, prefix="butler-")
+        config = daf_butler.Config(local_repo_config)
+        new_config = daf_butler.Butler.makeRepo(repo_dir.name,
+                                                config=config,
+                                                dimensionConfig=dimension_config,
+                                                )
+        _log.info("Created local Butler repo at %s with dimensions-config %s %d.",
+                  repo_dir.name, dimension_config["namespace"], dimension_config["version"])
+
+        # Run-once repository initialization
+        with daf_butler.Butler(new_config, writeable=True) as butler:
+            instrument.register(butler.registry)
+
+            # Need standard collections to exist, but don't need chains to be initialized
+            butler.collections.register(instrument.makeUmbrellaCollectionName(),
+                                        daf_butler.CollectionType.CHAINED)
+            butler.collections.register(instrument.makeCalibrationCollectionName(),
+                                        daf_butler.CollectionType.CHAINED)
+            butler.collections.register(instrument.makeUnboundedCalibrationRunName(),
+                                        daf_butler.CollectionType.RUN)
+            butler.collections.register(instrument.makeRefCatCollectionName(),
+                                        daf_butler.CollectionType.CHAINED)
+            butler.collections.register(instrument.makeDefaultRawIngestRunName(),
+                                        daf_butler.CollectionType.RUN)
+
+        return repo_dir
+
+    @classmethod
+    def _make_local_butler(cls, repo_dir: str, instrument: obs_base.Instrument) -> daf_butler.Butler:
+        """Set up a persistent writeable Butler for the local repo.
+
+        Parameters
+        ----------
+        repo_dir : `str`
+            A path to the repo location.
+        instrument : `lsst.obs.base.Instrument`
+            The instrument whose data should be searched.
+
+        Returns
+        -------
+        butler : `lsst.daf.butler.Butler`
+            A general-purpose Butler.
+        """
+        return daf_butler.Butler(repo_dir,
+                                 collections=instrument.makeUmbrellaCollectionName(),
+                                 writeable=True,
+                                 )
+
+    @classmethod
+    def _make_local_cache(cls):
+        """Set up a cache for preloaded datasets.
+
+        Returns
+        -------
+        cache : `activator.caching.DatasetCache`
+            An empty cache with configured caching strategy and limits.
+        """
+        return DatasetCache(base_keep_limit)
+
+    def __del__(self):
+        """Safety net finalizer for LocalRepo.
+        """
+        if not self._closed:
+            warnings.warn(f"{self!r} has not been properly closed, attempting to close it.", ResourceWarning)
+        self.close()
+
+    def close(self):
+        """Clean up the repository and all associated resources.
+        """
+        # Object may be only partially initialized
+        if hasattr(self, "_butler") and self._butler:
+            self._butler.close()
+        if hasattr(self, "_repo") and self._repo:
+            self._repo.cleanup()
+        self._closed = True
+
+    def load_from(self, src_butler, refs, *, no_cache_runs=None):
+        """Ensure the indicated datasets are loaded into this repository.
+
+        Datasets are not re-loaded if they're already present. Other datasets
+        may be removed to make room, according to this object's caching
+        strategy.
+
+        Parameters
+        ----------
+        src_butler : `lsst.daf.butler.Butler`
+            The Butler from which to transfer any missing datasets.
+        refs : collection [`lsst.daf.butler.DatasetRef`]
+            The datasets to load into this repository.
+        no_cache_runs : collection [`str`], optional
+            Any collection(s) whose contents should not be managed by a cache
+            (e.g., because the collections will be deleted later).
+
+        Returns
+        -------
+        present_refs : collection [`lsst.daf.butler.DatasetRef`]
+            The datasets either loaded into or already present in this repository.
+        """
+        if no_cache_runs is None:
+            no_cache_runs = set()
+
+        present = set(self._find_in_repo(refs))
+        missing = set(refs) - present
+        _log_trace.debug("Found %d matching datasets. %d present locally, %d to download.",
+                         len(refs), len(present), len(missing))
+        # Update cache as late as possible in case of earlier errors
+        cacheable = {d for d in refs
+                     # TODO: is there an efficient test for collection membership?
+                     if not d.datasetType.dimensions.spatial and d.run not in no_cache_runs}
+        self._cache_datasets(cacheable)
+        transferred = self._transfer_data(src_butler, missing)
+        return set(transferred) | present
+
+    def _find_in_repo(self,
+                      datasets: collections.abc.Collection[lsst.daf.butler.DatasetRef]
+                      ) -> collections.abc.Iterable[lsst.daf.butler.DatasetRef]:
+        """Identify which of a collection of datasets is present in this repo.
+
+        Parameters
+        ----------
+        datasets : collection [`~lsst.daf.butler.DatasetRef`]
+            The datasets to search for. Any past dataset transfers must preserve
+            dataset ID.
+
+        Returns
+        -------
+        datasets : iterable [`lsst.daf.butler.DatasetRef`]
+            The subset of ``datasets`` that exists in ``repo``.
+        """
+        return self.butler.get_many_datasets(ref.id for ref in datasets)
+
+    def _cache_datasets(self, refs: collections.abc.Iterable[daf_butler.DatasetRef]):
+        """Add or mark requested datasets in the cache.
+
+        Parameters
+        ----------
+        refs : iterable [`lsst.daf.butler.DatasetRef`]
+            The datasets to cache. Assumed to all fit inside the cache.
+        """
+        evicted = self._cache.update(refs)
+        self.butler.pruneDatasets(evicted, disassociate=True, unstore=True, purge=True)
+        try:
+            self._cache.access(refs)
+        except LookupError as e:
+            raise RuntimeError("Cache is too small for one run's worth of datasets.") from e
+
+    @connect.retry(2, DATASTORE_EXCEPTIONS, wait=repo_retry)
+    def _transfer_data(self, src_butler, datasets):
+        """Transfer datasets from the central repo to the local repo.
+
+        Parameters
+        ----------
+        src_butler : `lsst.daf.butler.Butler`
+            The source of the datasets to transfer.
+        datasets : set [`~lsst.daf.butler.DatasetRef`]
+            The datasets to transfer into the local repo. Assumed to be absent.
+
+        Returns
+        -------
+        transferred : collection [`lsst.daf.butler.DatasetRef`]
+            The datasets that were successfully transferred.
+        """
+        with lsst.utils.timer.time_this(_log, msg="load_from (transfer datasets)", level=logging.DEBUG):
+            transferred = self.butler.transfer_from(src_butler,
+                                                    datasets,
+                                                    transfer="copy",
+                                                    skip_missing=True,
+                                                    register_dataset_types=True,
+                                                    transfer_dimensions=True,
+                                                    )
+        return transferred
+
+    def export_calib_associations(self, src_butler, calib_collection, datasets):
+        """Export the associations between a set of datasets and a
+        calibration collection.
+
+        Parameters
+        ----------
+        src_butler : `lsst.daf.butler.Butler`
+            The Butler from which to copy associations.
+        calib_collection : `str`
+            The calibration collection, or a chain thereof, containing the
+            associations. The collection and any children must exist in both
+            the central and local repos.
+        datasets : iterable [`lsst.daf.butler.DatasetRef']
+            The calib datasets whose associations must be exported. Must be
+            certified in ``calib_collection`` in the central repo, and must
+            exist in the local repo.
+        """
+        collections = src_butler.collections
+        with src_butler.query() as query, \
+                src_butler.registry.caching_context():  # Nested loops produce lots of queries
+            for dataset in datasets:
+                dtype = dataset.datasetType
+                result = query.where(dataset.dataId) \
+                    .join_dataset_search(dtype, calib_collection) \
+                    .general(dtype.dimensions,
+                             dataset_fields={dtype.name: {"dataset_id", "run", "collection", "timespan"}},
+                             find_first=False,  # Required for timespan queries.
+                             )
+                # Associations include run membership, and possibly multiple calibration collections.
+                for association in daf_butler.DatasetAssociation.from_query_result(result, dtype):
+                    if collections.get_info(association.collection).type \
+                            == daf_butler.CollectionType.CALIBRATION \
+                            and association.ref == dataset:
+                        # TODO: workaround for DM-54682, raises MissingCollectionError if collection missing
+                        self.butler.collections.get_info(association.collection)
+                        # certify is designed to work on groups of datasets; in practice,
+                        # the total number of calibs (~1 of each type) is small enough that
+                        # grouping by timespan isn't worth it.
+                        try:
+                            self.butler.registry.certify(association.collection,
+                                                         [dataset],
+                                                         association.timespan)
+                        except sqlalchemy.exc.IntegrityError as e:
+                            raise ValueError(f"Dataset {dataset} does not exist in the local repo.") from e

--- a/python/activator/local_repo.py
+++ b/python/activator/local_repo.py
@@ -362,3 +362,30 @@ class LocalRepo:
                             # export_calib_associations with previously-loaded calibs.
                             _log_trace.debug("Skipped certifying %s over %s; association already exists.",
                                              dataset, association.timespan)
+
+    def sync_collections(self, src_butler, collection):
+        """Copy a collection and all its descendants to this repo.
+
+        This preserves the collection structure even if some child collections
+        do not have data. Syncing a collection does not export its datasets.
+
+        Parameters
+        ----------
+        src_butler : `lsst.daf.butler.Butler`
+            The Butler from which to copy collections.
+        collection : `str`
+            The collection to be synced. It is usually a CHAINED collection
+            and can have many children.
+        """
+        src = src_butler.collections
+        dest = self.butler.collections
+
+        # Store collection chains after all children guaranteed to exist
+        chains = {}
+        for child in src.query(collection, flatten_chains=True, include_chains=True):
+            info = src.get_info(child)
+            if info.type == daf_butler.CollectionType.CHAINED:
+                chains[child] = info.children
+            dest.register(child, info.type, info.doc)
+        for chain, children in chains.items():
+            dest.redefine_chain(chain, children)

--- a/python/activator/local_repo.py
+++ b/python/activator/local_repo.py
@@ -357,3 +357,8 @@ class LocalRepo:
                                                          association.timespan)
                         except sqlalchemy.exc.IntegrityError as e:
                             raise ValueError(f"Dataset {dataset} does not exist in the local repo.") from e
+                        except daf_butler.registry.ConflictingDefinitionError:
+                            # A bit risky, but I've only seen this exception after starting to call
+                            # export_calib_associations with previously-loaded calibs.
+                            _log_trace.debug("Skipped certifying %s over %s; association already exists.",
+                                             dataset, association.timespan)

--- a/python/activator/local_repo.py
+++ b/python/activator/local_repo.py
@@ -389,3 +389,67 @@ class LocalRepo:
             dest.register(child, info.type, info.doc)
         for chain, children in chains.items():
             dest.redefine_chain(chain, children)
+
+    def clean(self) -> None:
+        """Remove local repo content that is only needed for a single visit.
+
+        This includes raws and pipeline outputs.
+        """
+        with lsst.utils.timer.time_this(_log, msg="clean", level=logging.DEBUG):
+            # Make sure we get everything
+            self.butler.registry.refresh()
+
+            # Clean out raws
+            try:
+                raws = self.butler.query_datasets(
+                    "raw",
+                    collections=self._instrument.makeDefaultRawIngestRunName(),
+                    find_first=False,
+                    explain=False,  # Raws might not have been ingested.
+                )
+            except daf_butler.MissingDatasetTypeError:
+                raws = []
+            n_raws = len(raws)
+            if n_raws == 0:
+                _log_trace.debug("No raws to remove.")
+            else:
+                _log_trace.debug("Removing %d raw(s).", n_raws)
+                self.butler.pruneDatasets(raws, disassociate=True, unstore=True, purge=True)
+                _log_trace.debug("Successfully removed %d raw(s).", n_raws)
+
+            # Outputs are all in their own runs, so just drop them.
+            # TODO: dependency on our naming convention located outside shared/run_utils.py
+            try:
+                output_runs = self.butler.collections.query(self._instrument.makeCollectionName("runs"),
+                                                            collection_types=daf_butler.CollectionType.RUN)
+            except daf_butler.MissingCollectionError:
+                output_runs = []
+            for output_run in output_runs:
+                _log_trace.debug("Removing run %s.", output_run)
+                _remove_run_completely(self.butler, output_run)
+
+            # Clean out calibs, templates, and other preloaded datasets
+            _log_trace.debug("Cache contents: %s", self._cache)
+            excess_datasets = set()
+            for dataset_type in self.butler.registry.queryDatasetTypes(...):
+                excess_datasets |= set(self.butler.query_datasets(
+                    dataset_type, collections="*", find_first=False, explain=False))
+            excess_datasets -= frozenset(self._cache)
+            if excess_datasets:
+                _log_trace.debug("Clearing out %s.", excess_datasets)
+                self.butler.pruneDatasets(excess_datasets, disassociate=True, unstore=True, purge=True)
+
+
+def _remove_run_completely(butler, run):
+    """Remove a run and all references to it from a Butler.
+
+    Parameters
+    ---------
+    butler : `lsst.daf.butler.Butler`
+        The butler in which to search for refcat dataset types.
+    run : `str`
+        The run to remove.
+    """
+    for chain in butler.collections.get_info(run, include_parents=True).parents:
+        butler.collections.remove_from_chain(chain, [run])
+    butler.removeRuns([run])

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -45,7 +45,7 @@ from lsst.pipe.base.mp_graph_executor import MPGraphExecutor
 from lsst.pipe.base.separable_pipeline_executor import SeparablePipelineExecutor
 from lsst.pipe.base.single_quantum_executor import SingleQuantumExecutor
 from lsst.daf.butler import Butler, CollectionType, DatasetType, DatasetRef, Timespan, \
-    DataIdValueError, DimensionRecord, MissingDatasetTypeError, MissingCollectionError
+    DimensionRecord, MissingDatasetTypeError
 from lsst.daf.butler import Config as dafButlerConfig
 import lsst.dax.apdb
 import lsst.geom
@@ -783,14 +783,17 @@ class MiddlewareInterface:
         refcats : iterable [`lsst.daf.butler.DatasetRef`]
             The refcats to be exported, after any filtering.
         """
-        # Get shards from all refcats that overlap this region.
-        query = _generic_query([dataset_type],
-                               collections=self.instrument.makeRefCatCollectionName(),
-                               where="htm7.region OVERLAPS search_region",
-                               bind={"search_region": region},
-                               find_first=True,
-                               )
-        src_datasets = set(query(self.read_central_butler, "source datasets"))
+        src_datasets = set(self.read_central_butler.query_datasets(
+            dataset_type,
+            collections=self.instrument.makeRefCatCollectionName(),
+            where="htm7.region OVERLAPS search_region",
+            bind={"search_region": region},
+            find_first=True,
+            explain=False,
+            with_dimension_records=True,
+        ))
+        # Trace3 because, in many contexts, src_datasets is too large to print.
+        _log_trace3.debug("%s: %s", dataset_type.name, src_datasets)
         if not src_datasets:
             raise _MissingDatasetError("Source repo query found no matches.")
         # Don't cache refcats
@@ -828,14 +831,18 @@ class MiddlewareInterface:
                    "skymap": self.skymap_name,
                    "physical_filter": physical_filter,
                    }
-        query = _generic_query([dataset_type],
-                               collections=self._collection_template,
-                               data_id=data_id,
-                               where="patch.region OVERLAPS search_region",
-                               bind={"search_region": region},
-                               find_first=True,
-                               )
-        src_datasets = set(query(self.read_central_butler, "source datasets"))
+        src_datasets = set(self.read_central_butler.query_datasets(
+            dataset_type,
+            collections=self._collection_template,
+            data_id=data_id,
+            where="patch.region OVERLAPS search_region",
+            bind={"search_region": region},
+            find_first=True,
+            explain=False,
+            with_dimension_records=True,
+        ))
+        # Trace3 because, in many contexts, src_datasets is too large to print.
+        _log_trace3.debug("%s: %s", dataset_type.name, src_datasets)
         if not src_datasets:
             raise _MissingDatasetError("Source repo query found no matches.")
         # Don't cache templates
@@ -875,31 +882,19 @@ class MiddlewareInterface:
                          "without a specific filter.")
             return set()
 
-        def query_calibs_by_date(butler, label):
-            with butler.query() as query:
-                expr = query.expression_factory
-                query = query.where(data_id)
-                try:
-                    datasets = set(
-                        query.datasets(dataset_type,
-                                       self.instrument.makeCalibrationCollectionName(),
-                                       find_first=True)
-                        # where needs to come after datasets to pick up the type
-                        .where(expr[dataset_type.name].timespan.overlaps(calib_date))
-                        .with_dimension_records()
-                    )
-                except (DataIdValueError, MissingDatasetTypeError, MissingCollectionError) as e:
-                    # Dimensions/dataset type often invalid for fresh local repo,
-                    # where there are no, and never have been, any matching datasets.
-                    # May have dimensions but no collections if a previous preload failed.
-                    # These *are* a problem for the central repo, but can be caught later.
-                    _log.debug("%s query failed with %s.", label, e)
-                    datasets = set()
-                # Trace3 because, in many contexts, datasets is too large to print.
-                _log_trace3.debug("%s: %s", label, datasets)
-                return datasets
-
-        src_datasets = set(query_calibs_by_date(self.read_central_butler, "source datasets"))
+        with self.read_central_butler.query() as query:
+            expr = query.expression_factory
+            query = query.where(data_id)
+            src_datasets = set(
+                query.datasets(dataset_type,
+                               self.instrument.makeCalibrationCollectionName(),
+                               find_first=True)
+                # where needs to come after datasets to pick up the type
+                .where(expr[dataset_type.name].timespan.overlaps(calib_date))
+                .with_dimension_records()
+            )
+        # Trace3 because, in many contexts, datasets is too large to print.
+        _log_trace3.debug("%s: %s", dataset_type.name, src_datasets)
         if not src_datasets:
             raise _MissingDatasetError("Source repo query found no matches.")
         self._cache_datasets(src_datasets)
@@ -935,12 +930,17 @@ class MiddlewareInterface:
                    }
         if physical_filter:
             data_id["physical_filter"] = physical_filter
-        query = _generic_query([dataset_type],
-                               collections=self.instrument.makeUmbrellaCollectionName(),
-                               data_id=data_id,
-                               find_first=True,
-                               )
-        src_datasets = set(query(self.read_central_butler, "source datasets"))
+
+        src_datasets = set(self.read_central_butler.query_datasets(
+            dataset_type,
+            collections=self.instrument.makeUmbrellaCollectionName(),
+            data_id=data_id,
+            find_first=True,
+            explain=False,
+            with_dimension_records=True,
+        ))
+        # Trace3 because, in many contexts, src_datasets is too large to print.
+        _log_trace3.debug("%s: %s", dataset_type.name, src_datasets)
         if not src_datasets:
             raise _MissingDatasetError("Source repo query found no matches.")
         self._cache_datasets(src_datasets)
@@ -984,9 +984,16 @@ class MiddlewareInterface:
         datasets = set()
         for pipeline_file in self.get_combined_pipeline_files():
             run = runs.get_output_run(self.instrument, self._deployment, pipeline_file, self._day_obs)
-            types = self._get_init_output_types(pipeline_file)
-            query = _generic_query(types, collections=run)
-            datasets.update(query(self.read_central_butler, "source datasets"))
+            for dataset_type in self._get_init_output_types(pipeline_file):
+                new_datasets = set(self.read_central_butler.query_datasets(
+                    dataset_type,
+                    collections=run,
+                    explain=False,
+                    with_dimension_records=True,
+                ))
+                datasets.update(new_datasets)
+        # Trace3 because, in many contexts, datasets is too large to print.
+        _log_trace3.debug("Init datasets: %s", datasets)
         if not datasets:
             raise _MissingDatasetError("Source repo query found no matches.")
 
@@ -1935,48 +1942,6 @@ def _find_datasets_in_repo(repo: Butler,
         The subset of ``datasets`` that exists in ``repo``.
     """
     return repo.get_many_datasets(ref.id for ref in datasets)
-
-
-def _generic_query(dataset_types: collections.abc.Iterable[str | lsst.daf.butler.DatasetType],
-                   *args,
-                   **kwargs) -> collections.abc.Callable[[Butler, str], _DatasetResults]:
-    """Generate a parameterized Butler dataset query.
-
-    Parameters
-    ----------
-    dataset_types : iterable [`str` | `lsst.daf.butler.DatasetType`]
-        Iterable of dataset type object or name to search for.
-    *args, **kwargs
-        Parameters for describing the dataset query. They have the same
-        meanings as the parameters of `lsst.daf.butler.query_datasets`.
-
-    Returns
-    -------
-    query : callable
-        A callable that takes a `~lsst.daf.butler.Butler` and an optional
-        logging label and executes the dataset query, returning an iterable of
-        fully expanded `~lsst.daf.butler.DatasetRef`.
-    """
-    def query(butler: Butler, butler_name: str = ""):
-        label = butler_name or str(butler)
-        datasets = set()
-        for dataset_type in dataset_types:
-            try:
-                datasets |= set(butler.query_datasets(
-                    # explain=False because empty query result is ok here.
-                    dataset_type, explain=False, with_dimension_records=True, *args, **kwargs
-                ))
-            except (DataIdValueError, MissingDatasetTypeError, MissingCollectionError) as e:
-                # Dimensions/dataset type often invalid for fresh local repo,
-                # where there are no, and never have been, any matching datasets.
-                # May have dimensions but no collections if a previous preload failed.
-                # These *are* a problem for the central repo, but can be caught later.
-                _log.debug("%s query failed with %s.", label, e)
-        # Trace3 because, in many contexts, datasets is too large to print.
-        _log_trace3.debug("%s: %s", label, datasets)
-        return datasets
-
-    return query
 
 
 def _remove_run_completely(butler, run):

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -35,7 +35,6 @@ import yaml
 
 import astropy
 import botocore.exceptions
-import sqlalchemy.exc
 
 import lsst.utils.timer
 from lsst.resources import ResourcePath
@@ -64,6 +63,7 @@ from .caching import DatasetCache
 from .exception import GracefulShutdownInterrupt, TimeoutInterrupt, NonRetriableError, RetriableError, \
     InvalidPipelineError, NoGoodPipelinesError, PipelinePreExecutionError, PipelineExecutionError, \
     ProvenanceDimensionsError
+from .mw_retries import repo_retry, SQL_EXCEPTIONS, DATASTORE_EXCEPTIONS
 from .timer import enforce_schema, time_this_to_bundle
 
 _log = logging.getLogger("lsst." + __name__)
@@ -80,16 +80,8 @@ base_keep_limit = int(os.environ.get("LOCAL_REPO_CACHE_SIZE", 3))
 do_export = bool(int(os.environ.get("DEBUG_EXPORT_OUTPUTS", '1')))
 # The number of arcseconds to pad the region in preloading spatial datasets.
 padding = float(os.environ.get("PRELOAD_PADDING", 30))
-# The (jittered) number of seconds to delay retrying connections to the central Butler.
-repo_retry = float(os.environ.get("REPO_RETRY_DELAY", 30))
 # An optional file with local butler repo config overrides.
 local_repo_config = os.environ.get("LOCAL_REPO_CONFIG", None)
-
-
-# TODO: revisit which cases should be retried after DM-50934
-# TODO: catch ButlerConnectionError once it's available
-SQL_EXCEPTIONS = (sqlalchemy.exc.OperationalError, sqlalchemy.exc.InterfaceError)
-DATASTORE_EXCEPTIONS = SQL_EXCEPTIONS + (botocore.exceptions.ClientError, )
 
 
 @connect.retry(2, SQL_EXCEPTIONS, wait=repo_retry)

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -45,7 +45,7 @@ from lsst.pipe.base.mp_graph_executor import MPGraphExecutor
 from lsst.pipe.base.separable_pipeline_executor import SeparablePipelineExecutor
 from lsst.pipe.base.single_quantum_executor import SingleQuantumExecutor
 from lsst.daf.butler import Butler, CollectionType, DatasetType, DatasetRef, Timespan, \
-    DimensionRecord, MissingDatasetTypeError
+    DimensionRecord, MissingDatasetTypeError, EmptyQueryResultError
 from lsst.daf.butler import Config as dafButlerConfig
 import lsst.dax.apdb
 import lsst.geom
@@ -650,7 +650,7 @@ class MiddlewareInterface:
                     else:
                         all_datasets.update(self._find_generic_datasets(
                             dstype, self.visit.detector, self.visit.filters))
-                except _MissingDatasetError:
+                except EmptyQueryResultError:
                     _log.warning("Found no source datasets of type %s.", type_name)
                     present_types.remove(type_name)
 
@@ -789,13 +789,11 @@ class MiddlewareInterface:
             where="htm7.region OVERLAPS search_region",
             bind={"search_region": region},
             find_first=True,
-            explain=False,
+            explain=True,
             with_dimension_records=True,
         ))
         # Trace3 because, in many contexts, src_datasets is too large to print.
         _log_trace3.debug("%s: %s", dataset_type.name, src_datasets)
-        if not src_datasets:
-            raise _MissingDatasetError("Source repo query found no matches.")
         # Don't cache refcats
         known_datasets = set(_find_datasets_in_repo(self.butler, src_datasets))
         missing = src_datasets - known_datasets
@@ -838,13 +836,11 @@ class MiddlewareInterface:
             where="patch.region OVERLAPS search_region",
             bind={"search_region": region},
             find_first=True,
-            explain=False,
+            explain=True,
             with_dimension_records=True,
         ))
         # Trace3 because, in many contexts, src_datasets is too large to print.
         _log_trace3.debug("%s: %s", dataset_type.name, src_datasets)
-        if not src_datasets:
-            raise _MissingDatasetError("Source repo query found no matches.")
         # Don't cache templates
         known_datasets = set(_find_datasets_in_repo(self.butler, src_datasets))
         missing = src_datasets - known_datasets
@@ -893,10 +889,10 @@ class MiddlewareInterface:
                 .where(expr[dataset_type.name].timespan.overlaps(calib_date))
                 .with_dimension_records()
             )
+            if not src_datasets:
+                raise EmptyQueryResultError(list(query.explain_no_results()))
         # Trace3 because, in many contexts, datasets is too large to print.
         _log_trace3.debug("%s: %s", dataset_type.name, src_datasets)
-        if not src_datasets:
-            raise _MissingDatasetError("Source repo query found no matches.")
         self._cache_datasets(src_datasets)
         known_datasets = set(_find_datasets_in_repo(self.butler, src_datasets))
         missing = src_datasets - known_datasets
@@ -936,13 +932,11 @@ class MiddlewareInterface:
             collections=self.instrument.makeUmbrellaCollectionName(),
             data_id=data_id,
             find_first=True,
-            explain=False,
+            explain=True,
             with_dimension_records=True,
         ))
         # Trace3 because, in many contexts, src_datasets is too large to print.
         _log_trace3.debug("%s: %s", dataset_type.name, src_datasets)
-        if not src_datasets:
-            raise _MissingDatasetError("Source repo query found no matches.")
         self._cache_datasets(src_datasets)
         known_datasets = set(_find_datasets_in_repo(self.butler, src_datasets))
         missing = src_datasets - known_datasets
@@ -988,14 +982,12 @@ class MiddlewareInterface:
                 new_datasets = set(self.read_central_butler.query_datasets(
                     dataset_type,
                     collections=run,
-                    explain=False,
+                    explain=True,
                     with_dimension_records=True,
                 ))
                 datasets.update(new_datasets)
         # Trace3 because, in many contexts, datasets is too large to print.
         _log_trace3.debug("Init datasets: %s", datasets)
-        if not datasets:
-            raise _MissingDatasetError("Source repo query found no matches.")
 
         for run, n_datasets in self._count_by_key(datasets, lambda ref: ref.run):
             _log.debug("Found %d new init-output datasets from %s.", n_datasets, run)
@@ -1910,13 +1902,6 @@ class MiddlewareInterface:
             if excess_datasets:
                 _log_trace.debug("Clearing out %s.", excess_datasets)
                 self.butler.pruneDatasets(excess_datasets, disassociate=True, unstore=True, purge=True)
-
-
-class _MissingDatasetError(RuntimeError):
-    """An exception flagging that required datasets were not found
-    where expected.
-    """
-    pass
 
 
 _DatasetResults: typing.TypeAlias = collections.abc.Iterable[lsst.daf.butler.DatasetRef]

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -572,10 +572,22 @@ class MiddlewareInterface:
                     region = None
 
                 with time_this_to_bundle(bundle, action_id, "prep_butlerSearchTime"):
-                    all_datasets, calib_datasets = self._find_data_to_preload(region)
+                    all_datasets, calib_datasets = self._find_pipeline_inputs(region)
+                    present = set(_find_datasets_in_repo(self.butler, all_datasets))
+                    missing = all_datasets - present
+                    missing_calibs = calib_datasets - present
+                    _log_trace.debug("Found %d matching datasets. %d present locally, %d to download.",
+                                     len(all_datasets), len(present), len(missing))
+                    # Do this last, to avoid wasting evictions if any of the above code fails
+                    # Datasets in output collections are uncacheable because the runs will be deleted
+                    output_runs = {runs.get_output_run(self.instrument, self._deployment, f, self._day_obs)
+                                   for f in self.get_combined_pipeline_files()}
+                    cacheable = {d for d in all_datasets
+                                 if not d.datasetType.dimensions.spatial and d.run not in output_runs}
+                    self._cache_datasets(cacheable)
 
                 with time_this_to_bundle(bundle, action_id, "prep_butlerTransferTime"):
-                    self._transfer_data(all_datasets, calib_datasets)
+                    self._transfer_data(missing, missing_calibs)
 
                 with time_this_to_bundle(bundle, action_id, "prep_butlerPreprocessTime"):
                     try:
@@ -605,11 +617,10 @@ class MiddlewareInterface:
                         group=self.visit.groupId)
 
     @connect.retry(2, SQL_EXCEPTIONS, wait=repo_retry)
-    def _find_data_to_preload(self, region):
-        """Identify the datasets to export from the central repo.
+    def _find_pipeline_inputs(self, region):
+        """Identify the datasets needed for pipeline execution.
 
-        The returned datasets are a superset of those needed by any pipeline,
-        but exclude any datasets that are already present in the local repo.
+        The returned datasets are a superset of those needed by any pipeline.
 
         Parameters
         ----------
@@ -619,7 +630,7 @@ class MiddlewareInterface:
         Returns
         -------
         datasets : set [`~lsst.daf.butler.DatasetRef`]
-            The datasets to be exported, after any filtering.
+            The datasets needed by at least one pipeline.
         calibs : set [`~lsst.daf.butler.DatasetRef`]
             The subset of ``datasets`` representing calibs.
         """
@@ -769,7 +780,7 @@ class MiddlewareInterface:
                 for task in pipeline.tasks.values() for edge in task.iter_all_outputs()}
 
     def _find_refcats(self, dataset_type, region):
-        """Identify the refcats to export from the central butler.
+        """Identify the refcats needed for pipeline runs.
 
         Parameters
         ----------
@@ -781,7 +792,7 @@ class MiddlewareInterface:
         Returns
         -------
         refcats : iterable [`lsst.daf.butler.DatasetRef`]
-            The refcats to be exported, after any filtering.
+            The refcats needed to run pipelines on ``region``.
         """
         src_datasets = set(self.read_central_butler.query_datasets(
             dataset_type,
@@ -794,17 +805,11 @@ class MiddlewareInterface:
         ))
         # Trace3 because, in many contexts, src_datasets is too large to print.
         _log_trace3.debug("%s: %s", dataset_type.name, src_datasets)
-        # Don't cache refcats
-        known_datasets = set(_find_datasets_in_repo(self.butler, src_datasets))
-        missing = src_datasets - known_datasets
-        _log_trace.debug("Found %d matching datasets. %d present locally, %d to download.",
-                         len(src_datasets), len(known_datasets), len(missing))
-        if missing:
-            _log.debug("Found %d new refcat datasets from catalog '%s'.", len(missing), dataset_type.name)
-        return missing
+        _log.debug("Found %d refcat datasets from catalog '%s'.", len(src_datasets), dataset_type.name)
+        return src_datasets
 
     def _find_templates(self, dataset_type, region, physical_filter):
-        """Identify the templates to export from the central butler.
+        """Identify the templates needed for pipeline runs.
 
         Parameters
         ----------
@@ -819,7 +824,7 @@ class MiddlewareInterface:
         Returns
         -------
         templates : iterable [`lsst.daf.butler.DatasetRef`]
-            The datasets to be exported, after any filtering.
+            The templates needed to run pipelines on ``region``.
         """
         if not physical_filter:
             _log.warning("Preloading templates is not supported for visits without a specific filter.")
@@ -841,17 +846,11 @@ class MiddlewareInterface:
         ))
         # Trace3 because, in many contexts, src_datasets is too large to print.
         _log_trace3.debug("%s: %s", dataset_type.name, src_datasets)
-        # Don't cache templates
-        known_datasets = set(_find_datasets_in_repo(self.butler, src_datasets))
-        missing = src_datasets - known_datasets
-        _log_trace.debug("Found %d matching datasets. %d present locally, %d to download.",
-                         len(src_datasets), len(known_datasets), len(missing))
-        if missing:
-            _log.debug("Found %d new template datasets of type %s.", len(missing), dataset_type.name)
-        return missing
+        _log.debug("Found %d template datasets of type %s.", len(src_datasets), dataset_type.name)
+        return src_datasets
 
     def _find_calibs(self, dataset_type, detector_id, physical_filter):
-        """Identify the calibs to export from the central butler.
+        """Identify the calibs needed for pipeline runs.
 
         Parameters
         ----------
@@ -866,7 +865,7 @@ class MiddlewareInterface:
         Returns
         -------
         calibs : iterable [`lsst.daf.butler.DatasetRef`]
-            The calibs to be exported, after any filtering.
+            The calibs needed for running pipelines on the current visit.
         """
         # TAI observation start time should be used for calib validity range.
         calib_date = astropy.time.Time(self.visit.private_sndStamp, format="unix_tai")
@@ -893,17 +892,11 @@ class MiddlewareInterface:
                 raise EmptyQueryResultError(list(query.explain_no_results()))
         # Trace3 because, in many contexts, datasets is too large to print.
         _log_trace3.debug("%s: %s", dataset_type.name, src_datasets)
-        self._cache_datasets(src_datasets)
-        known_datasets = set(_find_datasets_in_repo(self.butler, src_datasets))
-        missing = src_datasets - known_datasets
-        _log_trace.debug("Found %d matching datasets. %d present locally, %d to download.",
-                         len(src_datasets), len(known_datasets), len(missing))
-        if missing:
-            _log.debug("Found %d new calib datasets of type '%s'.", len(missing), dataset_type.name)
-        return missing
+        _log.debug("Found %d calib datasets of type '%s'.", len(src_datasets), dataset_type.name)
+        return src_datasets
 
     def _find_generic_datasets(self, dataset_type, detector_id, physical_filter):
-        """Identify datasets to export from the central butler.
+        """Identify non-calib, non-spatial datasets needed for pipeline runs.
 
         Parameters
         ----------
@@ -918,7 +911,7 @@ class MiddlewareInterface:
         Returns
         -------
         datasets : iterable [`lsst.daf.butler.DatasetRef`]
-            The datasets to be exported, after any filtering.
+            The datasets needed for running pipelines on the current visit.
         """
         data_id = {"instrument": self.instrument.getName(),
                    "skymap": self.skymap_name,
@@ -937,14 +930,8 @@ class MiddlewareInterface:
         ))
         # Trace3 because, in many contexts, src_datasets is too large to print.
         _log_trace3.debug("%s: %s", dataset_type.name, src_datasets)
-        self._cache_datasets(src_datasets)
-        known_datasets = set(_find_datasets_in_repo(self.butler, src_datasets))
-        missing = src_datasets - known_datasets
-        _log_trace.debug("Found %d matching datasets. %d present locally, %d to download.",
-                         len(src_datasets), len(known_datasets), len(missing))
-        if missing:
-            _log.debug("Found %d new datasets of type %s.", len(missing), dataset_type.name)
-        return missing
+        _log.debug("Found %d datasets of type %s.", len(src_datasets), dataset_type.name)
+        return src_datasets
 
     def _get_init_output_types(self, pipeline_file):
         """Identify the specific init-output types to query.
@@ -990,7 +977,7 @@ class MiddlewareInterface:
         _log_trace3.debug("Init datasets: %s", datasets)
 
         for run, n_datasets in self._count_by_key(datasets, lambda ref: ref.run):
-            _log.debug("Found %d new init-output datasets from %s.", n_datasets, run)
+            _log.debug("Found %d init-output datasets from %s.", n_datasets, run)
         return datasets
 
     @connect.retry(2, DATASTORE_EXCEPTIONS, wait=repo_retry)

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -784,19 +784,23 @@ class MiddlewareInterface:
             The refcats to be exported, after any filtering.
         """
         # Get shards from all refcats that overlap this region.
-        refcats = set(_filter_datasets(
-                      self.read_central_butler, self.butler,
-                      _generic_query([dataset_type],
-                                     collections=self.instrument.makeRefCatCollectionName(),
-                                     where="htm7.region OVERLAPS search_region",
-                                     bind={"search_region": region},
-                                     find_first=True,
-                                     ),
-                      # Don't cache refcats
-                      ))
-        if refcats:
-            _log.debug("Found %d new refcat datasets from catalog '%s'.", len(refcats), dataset_type.name)
-        return refcats
+        query = _generic_query([dataset_type],
+                               collections=self.instrument.makeRefCatCollectionName(),
+                               where="htm7.region OVERLAPS search_region",
+                               bind={"search_region": region},
+                               find_first=True,
+                               )
+        src_datasets = set(query(self.read_central_butler, "source datasets"))
+        if not src_datasets:
+            raise _MissingDatasetError("Source repo query found no matches.")
+        # Don't cache refcats
+        known_datasets = set(_find_datasets_in_repo(self.butler, src_datasets))
+        missing = src_datasets - known_datasets
+        _log_trace.debug("Found %d matching datasets. %d present locally, %d to download.",
+                         len(src_datasets), len(known_datasets), len(missing))
+        if missing:
+            _log.debug("Found %d new refcat datasets from catalog '%s'.", len(missing), dataset_type.name)
+        return missing
 
     def _find_templates(self, dataset_type, region, physical_filter):
         """Identify the templates to export from the central butler.
@@ -824,20 +828,24 @@ class MiddlewareInterface:
                    "skymap": self.skymap_name,
                    "physical_filter": physical_filter,
                    }
-        templates = set(_filter_datasets(
-            self.read_central_butler, self.butler,
-            _generic_query([dataset_type],
-                           collections=self._collection_template,
-                           data_id=data_id,
-                           where="patch.region OVERLAPS search_region",
-                           bind={"search_region": region},
-                           find_first=True,
-                           ),
-            # Don't cache templates
-        ))
-        if templates:
-            _log.debug("Found %d new template datasets of type %s.", len(templates), dataset_type.name)
-        return templates
+        query = _generic_query([dataset_type],
+                               collections=self._collection_template,
+                               data_id=data_id,
+                               where="patch.region OVERLAPS search_region",
+                               bind={"search_region": region},
+                               find_first=True,
+                               )
+        src_datasets = set(query(self.read_central_butler, "source datasets"))
+        if not src_datasets:
+            raise _MissingDatasetError("Source repo query found no matches.")
+        # Don't cache templates
+        known_datasets = set(_find_datasets_in_repo(self.butler, src_datasets))
+        missing = src_datasets - known_datasets
+        _log_trace.debug("Found %d matching datasets. %d present locally, %d to download.",
+                         len(src_datasets), len(known_datasets), len(missing))
+        if missing:
+            _log.debug("Found %d new template datasets of type %s.", len(missing), dataset_type.name)
+        return missing
 
     def _find_calibs(self, dataset_type, detector_id, physical_filter):
         """Identify the calibs to export from the central butler.
@@ -891,14 +899,17 @@ class MiddlewareInterface:
                 _log_trace3.debug("%s: %s", label, datasets)
                 return datasets
 
-        calibs = set(_filter_datasets(
-            self.read_central_butler, self.butler,
-            query_calibs_by_date,
-            all_callback=self._cache_datasets,
-        ))
-        if calibs:
-            _log.debug("Found %d new calib datasets of type '%s'.", len(calibs), dataset_type.name)
-        return calibs
+        src_datasets = set(query_calibs_by_date(self.read_central_butler, "source datasets"))
+        if not src_datasets:
+            raise _MissingDatasetError("Source repo query found no matches.")
+        self._cache_datasets(src_datasets)
+        known_datasets = set(_find_datasets_in_repo(self.butler, src_datasets))
+        missing = src_datasets - known_datasets
+        _log_trace.debug("Found %d matching datasets. %d present locally, %d to download.",
+                         len(src_datasets), len(known_datasets), len(missing))
+        if missing:
+            _log.debug("Found %d new calib datasets of type '%s'.", len(missing), dataset_type.name)
+        return missing
 
     def _find_generic_datasets(self, dataset_type, detector_id, physical_filter):
         """Identify datasets to export from the central butler.
@@ -924,18 +935,22 @@ class MiddlewareInterface:
                    }
         if physical_filter:
             data_id["physical_filter"] = physical_filter
-        datasets = set(_filter_datasets(
-            self.read_central_butler, self.butler,
-            _generic_query([dataset_type],
-                           collections=self.instrument.makeUmbrellaCollectionName(),
-                           data_id=data_id,
-                           find_first=True,
-                           ),
-            all_callback=self._cache_datasets,
-        ))
-        if datasets:
-            _log.debug("Found %d new datasets of type %s.", len(datasets), dataset_type.name)
-        return datasets
+        query = _generic_query([dataset_type],
+                               collections=self.instrument.makeUmbrellaCollectionName(),
+                               data_id=data_id,
+                               find_first=True,
+                               )
+        src_datasets = set(query(self.read_central_butler, "source datasets"))
+        if not src_datasets:
+            raise _MissingDatasetError("Source repo query found no matches.")
+        self._cache_datasets(src_datasets)
+        known_datasets = set(_find_datasets_in_repo(self.butler, src_datasets))
+        missing = src_datasets - known_datasets
+        _log_trace.debug("Found %d matching datasets. %d present locally, %d to download.",
+                         len(src_datasets), len(known_datasets), len(missing))
+        if missing:
+            _log.debug("Found %d new datasets of type %s.", len(missing), dataset_type.name)
+        return missing
 
     def _get_init_output_types(self, pipeline_file):
         """Identify the specific init-output types to query.
@@ -970,8 +985,6 @@ class MiddlewareInterface:
         for pipeline_file in self.get_combined_pipeline_files():
             run = runs.get_output_run(self.instrument, self._deployment, pipeline_file, self._day_obs)
             types = self._get_init_output_types(pipeline_file)
-            # Output runs are always cleared after execution, so _filter_datasets would always warn.
-            # This also means the init-outputs don't need to be cached with _cache_datasets.
             query = _generic_query(types, collections=run)
             datasets.update(query(self.read_central_butler, "source datasets"))
         if not datasets:
@@ -1901,56 +1914,6 @@ class _MissingDatasetError(RuntimeError):
 
 _DatasetResults: typing.TypeAlias = collections.abc.Iterable[lsst.daf.butler.DatasetRef]
 """Type alias for dataset query results, to simplify annotations."""
-
-
-def _filter_datasets(src_repo: Butler,
-                     dest_repo: Butler,
-                     query: collections.abc.Callable[[Butler, str], _DatasetResults],
-                     all_callback: typing.Callable[[collections.abc.Iterable[lsst.daf.butler.DatasetRef]],
-                                                   typing.Any] | None = None,
-                     ) -> _DatasetResults:
-    """Identify datasets in a source repository, filtering out those already
-    present in a destination.
-
-    This function raises if nothing in the source repository matches the query criteria.
-
-    Parameters
-    ----------
-    src_repo : `lsst.daf.butler.Butler`
-        The repository in which a dataset must be present.
-    dest_repo : `lsst.daf.butler.Butler`
-        The repository in which a dataset must not be present.
-    query : callable
-        A callable that takes a `~lsst.daf.butler.Butler` and a logging label
-        and returns matching datasets. The query must be valid for both
-        ``src_repo`` and ``dest_repo``.
-    all_callback: callable, optional
-        If provided, a callable that is called with *all* datasets picked up by
-        the query, before filtering out those already present in ``dest_repo``.
-        This callable is not called if the query returns no results.
-
-    Returns
-    -------
-    datasets : iterable [`lsst.daf.butler.DatasetRef`]
-        The datasets that exist in ``src_repo`` but not ``dest_repo``.
-        datasetRefs are guaranteed to be fully expanded if and only if
-        ``query`` guarantees it.
-
-    Raises
-    ------
-    _MissingDatasetError
-        Raised if the query on ``src_repo`` failed to find any datasets.
-    """
-    src_datasets = set(query(src_repo, "source datasets"))
-    if not src_datasets:
-        raise _MissingDatasetError("Source repo query found no matches.")
-    if all_callback:
-        all_callback(src_datasets)
-    known_datasets = set(_find_datasets_in_repo(dest_repo, src_datasets))
-    missing = src_datasets - known_datasets
-    _log_trace.debug("Found %d matching datasets. %d present locally, %d to download.",
-                     len(src_datasets), len(known_datasets), len(missing))
-    return missing
 
 
 def _find_datasets_in_repo(repo: Butler,

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -1631,67 +1631,9 @@ class MiddlewareInterface:
                                   ) for t in matching_types
         )
 
-    def clean_local_repo(self) -> None:
-        """Remove local repo content that is only needed for a single visit.
-
-        This includes raws and pipeline outputs.
-        """
-        with lsst.utils.timer.time_this(_log, msg="clean_local_repo", level=logging.DEBUG):
-            self.butler.registry.refresh()
-
-            # Clean out raws
-            raws = self.butler.query_datasets(
-                "raw",
-                collections=self.instrument.makeDefaultRawIngestRunName(),
-                find_first=False,
-                explain=False,  # Raws might not have been ingested.
-            )
-            n_raws = len(raws)
-            if n_raws == 0:
-                _log_trace.debug("No raws to remove.")
-            else:
-                _log_trace.debug("Removing %d raw(s).", n_raws)
-                self.butler.pruneDatasets(raws, disassociate=True, unstore=True, purge=True)
-                _log_trace.debug("Successfully removed %d raw(s).", n_raws)
-
-            # Outputs are all in their own runs, so just drop them.
-            preload_run = runs.get_preload_run(self.instrument, self._deployment, self._day_obs)
-            _remove_run_completely(self.butler, preload_run)
-            for pipeline_file in self.get_combined_pipeline_files():
-                output_run = runs.get_output_run(self.instrument, self._deployment, pipeline_file,
-                                                 self._day_obs)
-                _log_trace.debug("Removing run %s.", output_run)
-                _remove_run_completely(self.butler, output_run)
-
-            # Clean out calibs, templates, and other preloaded datasets
-            _log_trace.debug("Cache contents: %s", self.repo._cache)  # TODO: move into LocalRepo
-            excess_datasets = set()
-            for dataset_type in self.butler.registry.queryDatasetTypes(...):
-                excess_datasets |= set(self.butler.query_datasets(
-                    dataset_type, collections="*", find_first=False, explain=False))
-            excess_datasets -= frozenset(self.repo._cache)  # TODO: move into LocalRepo
-            if excess_datasets:
-                _log_trace.debug("Clearing out %s.", excess_datasets)
-                self.butler.pruneDatasets(excess_datasets, disassociate=True, unstore=True, purge=True)
-
 
 _DatasetResults: typing.TypeAlias = collections.abc.Iterable[lsst.daf.butler.DatasetRef]
 """Type alias for dataset query results, to simplify annotations."""
-
-
-def _remove_run_completely(butler, run):
-    """Remove a run and all references to it from a Butler.
-
-    Parameters
-    ---------
-    butler : `lsst.daf.butler.Butler`
-        The butler in which to search for refcat dataset types.
-    run : `str`
-        The run to remove.
-    """
-    for chain in butler.collections.get_info(run, include_parents=True).parents:
-        butler.collections.remove_from_chain(chain, [run])
-    butler.removeRuns([run])
 
 
 def _check_transfer_completion(expected, transferred, transfer_type):

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -359,7 +359,7 @@ class MiddlewareInterface:
         now = astropy.time.Time.now()
         self._day_obs = runs.get_day_obs(now)
 
-        self._init_local_butler(local_repo, [self.instrument.makeUmbrellaCollectionName()], None)
+        self._init_local_butler(local_repo, [self.instrument.makeUmbrellaCollectionName()])
         self._init_governor_datasets(now, skymap)
         self.cache = local_cache  # DO NOT copy -- we want to persist this state!
         self._prep_collections()
@@ -388,7 +388,7 @@ class MiddlewareInterface:
             self.butler.close()
         self._closed = True
 
-    def _init_local_butler(self, repo_uri: str, output_collections: list[str], output_run: str):
+    def _init_local_butler(self, repo_uri: str, output_collections: list[str]):
         """Prepare the local butler to ingest into and process from.
 
         ``self.butler`` is correctly initialized after this method returns.
@@ -399,14 +399,11 @@ class MiddlewareInterface:
             A URI to the location of the local repository.
         output_collections : `list` [`str`]
             The collection(s) in which to search for inputs and outputs.
-        output_run : `str`
-            The run in which to place new pipeline outputs.
         """
         # Internal Butler keeps a reference to the newly prepared collection.
         # This reference makes visible any inputs for query purposes.
         self.butler = Butler(repo_uri,
                              collections=output_collections,
-                             run=output_run,
                              writeable=True,
                              )
 

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -1941,19 +1941,37 @@ def _filter_datasets(src_repo: Butler,
     _MissingDatasetError
         Raised if the query on ``src_repo`` failed to find any datasets.
     """
-    known_datasets = set(query(dest_repo, "known datasets"))
-
-    # Let exceptions from src_repo query raise: if it fails, that invalidates
-    # this operation.
     src_datasets = set(query(src_repo, "source datasets"))
     if not src_datasets:
         raise _MissingDatasetError("Source repo query found no matches.")
     if all_callback:
         all_callback(src_datasets)
+    known_datasets = set(_find_datasets_in_repo(dest_repo, src_datasets))
     missing = src_datasets - known_datasets
     _log_trace.debug("Found %d matching datasets. %d present locally, %d to download.",
-                     len(src_datasets), len(src_datasets & known_datasets), len(missing))
+                     len(src_datasets), len(known_datasets), len(missing))
     return missing
+
+
+def _find_datasets_in_repo(repo: Butler,
+                           datasets: collections.abc.Collection[lsst.daf.butler.DatasetRef],
+                           ) -> _DatasetResults:
+    """Identify which of a collection of datasets is present in a repo.
+
+    Parameters
+    ----------
+    repo : `lsst.daf.butler.Butler`
+        The repository to search.
+    datasets : collection [`~lsst.daf.butler.DatasetRef`]
+        The datasets to search for. Any past dataset transfers must preserve
+        dataset ID.
+
+    Returns
+    -------
+    datasets : iterable [`lsst.daf.butler.DatasetRef`]
+        The subset of ``datasets`` that exists in ``repo``.
+    """
+    return repo.get_many_datasets(ref.id for ref in datasets)
 
 
 def _generic_query(dataset_types: collections.abc.Iterable[str | lsst.daf.butler.DatasetType],

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -19,8 +19,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-__all__ = ["get_central_butler", "make_local_repo", "make_local_cache",
-           "MiddlewareInterface"]
+__all__ = ["get_central_butler", "MiddlewareInterface"]
 
 import collections.abc
 import functools
@@ -45,7 +44,6 @@ from lsst.pipe.base.separable_pipeline_executor import SeparablePipelineExecutor
 from lsst.pipe.base.single_quantum_executor import SingleQuantumExecutor
 from lsst.daf.butler import Butler, CollectionType, DatasetType, DatasetRef, Timespan, \
     DimensionRecord, MissingDatasetTypeError, EmptyQueryResultError
-from lsst.daf.butler import Config as dafButlerConfig
 import lsst.dax.apdb
 import lsst.geom
 import lsst.obs.base
@@ -59,10 +57,10 @@ from shared.config import PipelinesConfig
 import shared.connect_utils as connect
 import shared.run_utils as runs
 from shared.visit import FannedOutVisit
-from .caching import DatasetCache
 from .exception import GracefulShutdownInterrupt, TimeoutInterrupt, NonRetriableError, RetriableError, \
     InvalidPipelineError, NoGoodPipelinesError, PipelinePreExecutionError, PipelineExecutionError, \
     ProvenanceDimensionsError
+from .local_repo import LocalRepo
 from .mw_retries import repo_retry, SQL_EXCEPTIONS, DATASTORE_EXCEPTIONS
 from .timer import enforce_schema, time_this_to_bundle
 
@@ -74,14 +72,10 @@ _log_trace.setLevel(logging.CRITICAL)  # Turn off by default.
 _log_trace3 = logging.getLogger("TRACE3.lsst." + __name__)
 _log_trace3.setLevel(logging.CRITICAL)  # Turn off by default.
 
-# The number of calib datasets to keep, including the current run.
-base_keep_limit = int(os.environ.get("LOCAL_REPO_CACHE_SIZE", 3))
 # Whether or not to export to the central repo.
 do_export = bool(int(os.environ.get("DEBUG_EXPORT_OUTPUTS", '1')))
 # The number of arcseconds to pad the region in preloading spatial datasets.
 padding = float(os.environ.get("PRELOAD_PADDING", 30))
-# An optional file with local butler repo config overrides.
-local_repo_config = os.environ.get("LOCAL_REPO_CONFIG", None)
 
 
 @connect.retry(2, SQL_EXCEPTIONS, wait=repo_retry)
@@ -112,59 +106,6 @@ def get_central_butler(central_repo: str, instrument_class: str, writeable: bool
                   writeable=writeable,
                   inferDefaults=False,
                   )
-
-
-def make_local_repo(local_storage: str, central_butler: Butler, instrument: str):
-    """Create and configure a new local repository.
-
-    The repository is represented by a temporary directory object, which can be
-    used to manage its lifetime.
-
-    Parameters
-    ----------
-    local_storage : `str`
-        An absolute path to a space where this function can create a local
-        Butler repo.
-    central_butler : `lsst.daf.butler.Butler`
-        Butler repo containing instrument and skymap definitions.
-    instrument : `str`
-        Name of the instrument taking the data, for populating
-        butler collections and dataIds. May be either the fully qualified class
-        name or the short name. Examples: "LsstCam", "lsst.obs.lsst.LsstCam".
-
-    Returns
-    -------
-    repo_dir
-        An object of the same type as returned by `tempfile.TemporaryDirectory`,
-        pointing to the local repo location.
-    """
-    dimension_config = central_butler.dimensions.dimensionConfig
-    repo_dir = tempfile.TemporaryDirectory(dir=local_storage, prefix="butler-")
-    config = dafButlerConfig(local_repo_config)
-    new_config = Butler.makeRepo(repo_dir.name, config=config, dimensionConfig=dimension_config)
-    _log.info("Created local Butler repo at %s with dimensions-config %s %d.",
-              repo_dir.name, dimension_config["namespace"], dimension_config["version"])
-
-    # Run-once repository initialization
-    with Butler(new_config, writeable=True) as butler:
-        instrument = lsst.obs.base.Instrument.from_string(instrument, central_butler.registry)
-        instrument.register(butler.registry)
-
-        butler.collections.register(instrument.makeUmbrellaCollectionName(), CollectionType.CHAINED)
-        butler.collections.register(instrument.makeDefaultRawIngestRunName(), CollectionType.RUN)
-
-    return repo_dir
-
-
-def make_local_cache():
-    """Set up a cache for preloaded datasets.
-
-    Returns
-    -------
-    cache : `activator.caching.DatasetCache`
-        An empty cache with configured caching strategy and limits.
-    """
-    return DatasetCache(base_keep_limit)
 
 
 def _get_sasquatch_dispatcher():
@@ -281,12 +222,8 @@ class MiddlewareInterface:
         Information about which pipelines to run on ``visit``'s raws.
     skymap : `str`
         Name of the skymap in the central repo for querying templates.
-    local_repo : `str`
-        A URI to the local Butler repo, which is assumed to already exist and
-        contain standard collections and the registration of ``instrument``.
-    local_cache : `activator.caching.DatasetCache`
-        A cache holding datasets and usage history for preloaded dataset types
-        in ``local_repo``.
+    local_repo : `activator.local_repo.LocalRepo`
+        An object representing this worker's unique local repo.
     prefix : `str`, optional
         URI scheme followed by ``://``; prepended to ``image_bucket`` when
         constructing URIs to retrieve incoming files. The default is
@@ -320,15 +257,12 @@ class MiddlewareInterface:
     #   guaranteed to contain concrete data, or even the dimensions
     #   corresponding to self.camera and self.skymap. Do not assume that
     #   self.butler is the only Butler pointing to the local repo.
-    # self.butler is usable if and only if self._closed is False
 
     def __init__(self, read_butler: Butler, butler_writer: ButlerWriter, image_bucket: str,
                  visit: FannedOutVisit,
                  pre_pipelines: PipelinesConfig, main_pipelines: PipelinesConfig,
-                 # TODO: encapsulate relationship between local_repo and local_cache
-                 skymap: str, local_repo: str, local_cache: DatasetCache,
+                 skymap: str, local_repo: LocalRepo,
                  prefix: str = "s3://"):
-        self._closed = False
         self.visit = visit
 
         self._apdb_config = os.environ["CONFIG_APDB"]
@@ -351,9 +285,9 @@ class MiddlewareInterface:
         now = astropy.time.Time.now()
         self._day_obs = runs.get_day_obs(now)
 
-        self._init_local_butler(local_repo, [self.instrument.makeUmbrellaCollectionName()])
+        self.repo = local_repo
+        self.butler = self.repo.butler  # TODO: remove this after finish migrating to LocalRepo
         self._init_governor_datasets(now, skymap)
-        self.cache = local_cache  # DO NOT copy -- we want to persist this state!
         self._prep_collections()
         self._define_dimensions()
         self._init_ingester()
@@ -363,46 +297,8 @@ class MiddlewareInterface:
         # How much to pad the spatial region we will copy over.
         self.padding = padding*lsst.geom.arcseconds
 
-    def __del__(self):
-        """Safety-net finalizer for MiddlewareInterface.
-        """
-        if not self._closed:
-            _log.warning("%r has not been properly closed, attempting to close it.", self)
-        self.close()
-
-    # TODO: remove on DM-47743
-    def close(self):
-        """Clean up this object.
-
-        This method is idempotent.
-        """
-        if self.butler:
-            self.butler.close()
-        self._closed = True
-
-    def _init_local_butler(self, repo_uri: str, output_collections: list[str]):
-        """Prepare the local butler to ingest into and process from.
-
-        ``self.butler`` is correctly initialized after this method returns.
-
-        Parameters
-        ----------
-        repo_uri : `str`
-            A URI to the location of the local repository.
-        output_collections : `list` [`str`]
-            The collection(s) in which to search for inputs and outputs.
-        """
-        # Internal Butler keeps a reference to the newly prepared collection.
-        # This reference makes visible any inputs for query purposes.
-        self.butler = Butler(repo_uri,
-                             collections=output_collections,
-                             writeable=True,
-                             )
-
     def _init_ingester(self):
         """Prepare the raw file ingester to receive images into this butler.
-
-        ``self._init_local_butler`` must have already been run.
         """
         config = lsst.obs.base.RawIngestConfig()
         self.instrument.applyConfigOverrides(lsst.obs.base.RawIngestTask._DefaultName, config)
@@ -413,8 +309,6 @@ class MiddlewareInterface:
 
     def _init_visit_definer(self):
         """Prepare the visit definer to define visits for this butler.
-
-        ``self._init_local_butler`` must have already been run.
         """
         define_visits_config = lsst.obs.base.DefineVisitsConfig()
         self.instrument.applyConfigOverrides(lsst.obs.base.DefineVisitsTask._DefaultName,
@@ -425,8 +319,6 @@ class MiddlewareInterface:
     @connect.retry(2, DATASTORE_EXCEPTIONS, wait=repo_retry)
     def _init_governor_datasets(self, timestamp, skymap):
         """Load and store the camera and skymap for later use.
-
-        ``self._init_local_butler`` must have already been run.
 
         Parameters
         ----------
@@ -451,8 +343,6 @@ class MiddlewareInterface:
 
     def _init_provenance_dataset_type(self):
         """Register the dataset types used to store provenance information.
-
-        ``self._init_local_butler`` must have already been run.
         """
         self._provenance_dataset_type = DatasetType(
             "prompt_provenance",
@@ -463,28 +353,11 @@ class MiddlewareInterface:
 
     def _define_dimensions(self):
         """Define any dimensions that must be computed from this object's visit.
-
-        ``self._init_local_butler`` must have already been run.
         """
         self.butler.registry.syncDimensionData("group",
                                                {"name": self.visit.groupId,
                                                 "instrument": self.instrument.getName(),
                                                 })
-
-    def _cache_datasets(self, refs: collections.abc.Iterable[lsst.daf.butler.DatasetRef]):
-        """Add or mark requested datasets in the cache.
-
-        Parameters
-        ----------
-        refs : iterable [`lsst.daf.butler.DatasetRef`]
-            The datasets to cache. Assumed to all fit inside the cache.
-        """
-        evicted = self.cache.update(refs)
-        self.butler.pruneDatasets(evicted, disassociate=True, unstore=True, purge=True)
-        try:
-            self.cache.access(refs)
-        except LookupError as e:
-            raise RuntimeError("Cache is too small for one run's worth of datasets.") from e
 
     def _pad_region(self,
                     initial_region: lsst.sphgeom.Region,
@@ -565,21 +438,39 @@ class MiddlewareInterface:
 
                 with time_this_to_bundle(bundle, action_id, "prep_butlerSearchTime"):
                     all_datasets, calib_datasets = self._find_pipeline_inputs(region)
-                    present = set(_find_datasets_in_repo(self.butler, all_datasets))
-                    missing = all_datasets - present
-                    missing_calibs = calib_datasets - present
-                    _log_trace.debug("Found %d matching datasets. %d present locally, %d to download.",
-                                     len(all_datasets), len(present), len(missing))
-                    # Do this last, to avoid wasting evictions if any of the above code fails
-                    # Datasets in output collections are uncacheable because the runs will be deleted
-                    output_runs = {runs.get_output_run(self.instrument, self._deployment, f, self._day_obs)
-                                   for f in self.get_combined_pipeline_files()}
-                    cacheable = {d for d in all_datasets
-                                 if not d.datasetType.dimensions.spatial and d.run not in output_runs}
-                    self._cache_datasets(cacheable)
 
                 with time_this_to_bundle(bundle, action_id, "prep_butlerTransferTime"):
-                    self._transfer_data(missing, missing_calibs)
+                    output_runs = {runs.get_output_run(self.instrument, self._deployment, f, self._day_obs)
+                                   for f in self.get_combined_pipeline_files()}
+                    transferred = self.repo.load_from(self.read_central_butler, all_datasets,
+                                                      no_cache_runs=output_runs)
+                    missing = _check_transfer_completion(all_datasets, transferred, "Downloaded")
+
+                    with lsst.utils.timer.time_this(_log,
+                                                    msg="prep_butler (transfer collections)",
+                                                    level=logging.DEBUG):
+                        self._export_collections(self._collection_template)
+                        self._export_collections(self.instrument.makeUmbrellaCollectionName())
+
+                    # Must be called after collections have been exported
+                    # TODO: find a way to encapsulate collection sync + association sync in LocalRepo
+                    # while still letting MWI specify the collection names.
+                    with lsst.utils.timer.time_this(_log,
+                                                    msg="prep_butler (transfer associations)",
+                                                    level=logging.DEBUG):
+                        self.repo.export_calib_associations(
+                            self.read_central_butler,
+                            self.instrument.makeCalibrationCollectionName(),
+                            calib_datasets - missing)
+
+                    # Temporary workarounds until we have a prompt-processing default top-level collection
+                    # in shared repos, and raw collection in dev repo, and then we can organize collections
+                    # without worrying about DRP use cases.
+                    self.butler.collections.prepend_chain(
+                        self.instrument.makeUmbrellaCollectionName(),
+                        [self._collection_template,
+                         self.instrument.makeDefaultRawIngestRunName(),
+                         ])
 
                 with time_this_to_bundle(bundle, action_id, "prep_butlerPreprocessTime"):
                     try:
@@ -972,45 +863,6 @@ class MiddlewareInterface:
             _log.debug("Found %d init-output datasets from %s.", n_datasets, run)
         return datasets
 
-    @connect.retry(2, DATASTORE_EXCEPTIONS, wait=repo_retry)
-    def _transfer_data(self, datasets, calibs):
-        """Transfer datasets and all associated collections from the central
-        repo to the local repo.
-
-        Parameters
-        ----------
-        datasets : set [`~lsst.daf.butler.DatasetRef`]
-            The datasets to transfer into the local repo.
-        calibs : set [`~lsst.daf.butler.DatasetRef`]
-            The calibs to re-certify into the local repo.
-        """
-        with lsst.utils.timer.time_this(_log, msg="prep_butler (transfer datasets)", level=logging.DEBUG):
-            transferred = self.butler.transfer_from(self.read_central_butler,
-                                                    datasets,
-                                                    transfer="copy",
-                                                    skip_missing=True,
-                                                    register_dataset_types=True,
-                                                    transfer_dimensions=True,
-                                                    )
-            missing = _check_transfer_completion(datasets, transferred, "Downloaded")
-
-        with lsst.utils.timer.time_this(_log, msg="prep_butler (transfer collections)", level=logging.DEBUG):
-            self._export_collections(self._collection_template)
-            self._export_collections(self.instrument.makeUmbrellaCollectionName())
-
-        with lsst.utils.timer.time_this(_log, msg="prep_butler (transfer associations)", level=logging.DEBUG):
-            self._export_calib_associations(self.instrument.makeCalibrationCollectionName(),
-                                            calibs - missing)
-
-        # Temporary workarounds until we have a prompt-processing default top-level collection
-        # in shared repos, and raw collection in dev repo, and then we can organize collections
-        # without worrying about DRP use cases.
-        self.butler.collections.prepend_chain(
-            self.instrument.makeUmbrellaCollectionName(),
-            [self._collection_template,
-             self.instrument.makeDefaultRawIngestRunName(),
-             ])
-
     def _export_collections(self, collection):
         """Export the collection and all its children.
 
@@ -1036,41 +888,6 @@ class MiddlewareInterface:
                                     src.getCollectionDocumentation(child))
         for chain, children in chains.items():
             dest.setCollectionChain(chain, children)
-
-    def _export_calib_associations(self, calib_collection, datasets):
-        """Export the associations between a set of datasets and a
-        calibration collection.
-
-        Parameters
-        ----------
-        calib_collection : `str`
-            The calibration collection, or a chain thereof, containing the
-            associations. The collection and any children must exist in both
-            the central and local repos.
-        datasets : iterable [`lsst.daf.butler.DatasetRef']
-            The calib datasets whose associations must be exported. Must be
-            certified in ``calib_collection`` in the central repo, and must
-            exist in the local repo.
-        """
-        collections = self.read_central_butler.collections
-        with self.read_central_butler.query() as query, \
-                self.read_central_butler.registry.caching_context():  # Nested loops produce lots of queries
-            for dataset in datasets:
-                dtype = dataset.datasetType
-                result = query.where(dataset.dataId) \
-                    .join_dataset_search(dtype, calib_collection) \
-                    .general(dtype.dimensions,
-                             dataset_fields={dtype.name: {"dataset_id", "run", "collection", "timespan"}},
-                             find_first=False,  # Required for timespan queries.
-                             )
-                # Associations include run membership, and possibly multiple calibration collections.
-                for association in lsst.daf.butler.DatasetAssociation.from_query_result(result, dtype):
-                    if collections.get_info(association.collection).type == CollectionType.CALIBRATION \
-                            and association.ref == dataset:
-                        # certify is designed to work on groups of datasets; in practice,
-                        # the total number of calibs (~1 of each type) is small enough that
-                        # grouping by timespan isn't worth it.
-                        self.butler.registry.certify(association.collection, [dataset], association.timespan)
 
     @staticmethod
     def _count_by_key(refs, keyfunc):
@@ -1872,12 +1689,12 @@ class MiddlewareInterface:
                 _remove_run_completely(self.butler, output_run)
 
             # Clean out calibs, templates, and other preloaded datasets
-            _log_trace.debug("Cache contents: %s", self.cache)
+            _log_trace.debug("Cache contents: %s", self.repo._cache)  # TODO: move into LocalRepo
             excess_datasets = set()
             for dataset_type in self.butler.registry.queryDatasetTypes(...):
                 excess_datasets |= set(self.butler.query_datasets(
                     dataset_type, collections="*", find_first=False, explain=False))
-            excess_datasets -= frozenset(self.cache)
+            excess_datasets -= frozenset(self.repo._cache)  # TODO: move into LocalRepo
             if excess_datasets:
                 _log_trace.debug("Clearing out %s.", excess_datasets)
                 self.butler.pruneDatasets(excess_datasets, disassociate=True, unstore=True, purge=True)
@@ -1885,27 +1702,6 @@ class MiddlewareInterface:
 
 _DatasetResults: typing.TypeAlias = collections.abc.Iterable[lsst.daf.butler.DatasetRef]
 """Type alias for dataset query results, to simplify annotations."""
-
-
-def _find_datasets_in_repo(repo: Butler,
-                           datasets: collections.abc.Collection[lsst.daf.butler.DatasetRef],
-                           ) -> _DatasetResults:
-    """Identify which of a collection of datasets is present in a repo.
-
-    Parameters
-    ----------
-    repo : `lsst.daf.butler.Butler`
-        The repository to search.
-    datasets : collection [`~lsst.daf.butler.DatasetRef`]
-        The datasets to search for. Any past dataset transfers must preserve
-        dataset ID.
-
-    Returns
-    -------
-    datasets : iterable [`lsst.daf.butler.DatasetRef`]
-        The subset of ``datasets`` that exists in ``repo``.
-    """
-    return repo.get_many_datasets(ref.id for ref in datasets)
 
 
 def _remove_run_completely(butler, run):

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -449,8 +449,9 @@ class MiddlewareInterface:
                     with lsst.utils.timer.time_this(_log,
                                                     msg="prep_butler (transfer collections)",
                                                     level=logging.DEBUG):
-                        self._export_collections(self._collection_template)
-                        self._export_collections(self.instrument.makeUmbrellaCollectionName())
+                        self.repo.sync_collections(self.read_central_butler, self._collection_template)
+                        self.repo.sync_collections(self.read_central_butler,
+                                                   self.instrument.makeUmbrellaCollectionName())
 
                     # Must be called after collections have been exported
                     # TODO: find a way to encapsulate collection sync + association sync in LocalRepo
@@ -862,32 +863,6 @@ class MiddlewareInterface:
         for run, n_datasets in self._count_by_key(datasets, lambda ref: ref.run):
             _log.debug("Found %d init-output datasets from %s.", n_datasets, run)
         return datasets
-
-    def _export_collections(self, collection):
-        """Export the collection and all its children.
-
-        This preserves the collection structure even if some child collections
-        do not have data. Exporting a collection does not export its datasets.
-
-        Parameters
-        ----------
-        collection : `str`
-            The collection to be exported. It is usually a CHAINED collection
-            and can have many children.
-        """
-        src = self.read_central_butler.registry
-        dest = self.butler.registry
-
-        # Store collection chains after all children guaranteed to exist
-        chains = {}
-        for child in src.queryCollections(collection, flattenChains=True, includeChains=True):
-            if src.getCollectionType(child) == CollectionType.CHAINED:
-                chains[child] = src.getCollectionChain(child)
-            dest.registerCollection(child,
-                                    src.getCollectionType(child),
-                                    src.getCollectionDocumentation(child))
-        for chain, children in chains.items():
-            dest.setCollectionChain(chain, children)
 
     @staticmethod
     def _count_by_key(refs, keyfunc):

--- a/python/activator/middleware_interface.py
+++ b/python/activator/middleware_interface.py
@@ -252,11 +252,6 @@ class MiddlewareInterface:
     # self._download_store is None if and only if self.image_host is a local URI.
     # self.visit, self.instrument, self.camera, self.skymap, self._deployment
     #   self._day_obs do not change after __init__.
-    # self.butler defaults to the "defaults" chained collection, which contains
-    #   all pipeline inputs. However, self.butler is not
-    #   guaranteed to contain concrete data, or even the dimensions
-    #   corresponding to self.camera and self.skymap. Do not assume that
-    #   self.butler is the only Butler pointing to the local repo.
 
     def __init__(self, read_butler: Butler, butler_writer: ButlerWriter, image_bucket: str,
                  visit: FannedOutVisit,
@@ -286,7 +281,6 @@ class MiddlewareInterface:
         self._day_obs = runs.get_day_obs(now)
 
         self.repo = local_repo
-        self.butler = self.repo.butler  # TODO: remove this after finish migrating to LocalRepo
         self._init_governor_datasets(now, skymap)
         self._prep_collections()
         self._define_dimensions()
@@ -305,7 +299,7 @@ class MiddlewareInterface:
         config.transfer = "copy"  # Copy files into the local butler.
         config.failFast = True  # We want failed ingests to fail immediately.
         self.rawIngestTask = lsst.obs.base.RawIngestTask(config=config,
-                                                         butler=self.butler)
+                                                         butler=self.repo.butler)
 
     def _init_visit_definer(self):
         """Prepare the visit definer to define visits for this butler.
@@ -314,7 +308,8 @@ class MiddlewareInterface:
         self.instrument.applyConfigOverrides(lsst.obs.base.DefineVisitsTask._DefaultName,
                                              define_visits_config)
         define_visits_config.groupExposures = "one-to-one"
-        self.define_visits = lsst.obs.base.DefineVisitsTask(config=define_visits_config, butler=self.butler)
+        self.define_visits = lsst.obs.base.DefineVisitsTask(config=define_visits_config,
+                                                            butler=self.repo.butler)
 
     @connect.retry(2, DATASTORE_EXCEPTIONS, wait=repo_retry)
     def _init_governor_datasets(self, timestamp, skymap):
@@ -346,18 +341,18 @@ class MiddlewareInterface:
         """
         self._provenance_dataset_type = DatasetType(
             "prompt_provenance",
-            self.butler.dimensions.conform(["group", "detector"]),
+            self.repo.butler.dimensions.conform(["group", "detector"]),
             "ProvenanceQuantumGraph",
         )
-        self.butler.registry.registerDatasetType(self._provenance_dataset_type)
+        self.repo.butler.registry.registerDatasetType(self._provenance_dataset_type)
 
     def _define_dimensions(self):
         """Define any dimensions that must be computed from this object's visit.
         """
-        self.butler.registry.syncDimensionData("group",
-                                               {"name": self.visit.groupId,
-                                                "instrument": self.instrument.getName(),
-                                                })
+        self.repo.butler.registry.syncDimensionData("group",
+                                                    {"name": self.visit.groupId,
+                                                     "instrument": self.instrument.getName(),
+                                                     })
 
     def _pad_region(self,
                     initial_region: lsst.sphgeom.Region,
@@ -467,7 +462,7 @@ class MiddlewareInterface:
                     # Temporary workarounds until we have a prompt-processing default top-level collection
                     # in shared repos, and raw collection in dev repo, and then we can organize collections
                     # without worrying about DRP use cases.
-                    self.butler.collections.prepend_chain(
+                    self.repo.butler.collections.prepend_chain(
                         self.instrument.makeUmbrellaCollectionName(),
                         [self._collection_template,
                          self.instrument.makeDefaultRawIngestRunName(),
@@ -487,18 +482,18 @@ class MiddlewareInterface:
                                             "prep_butlerTransferTime",
                                             "prep_butlerPreprocessTime",
                                             ]})
-        self.butler.registry.registerDatasetType(DatasetType(
+        self.repo.butler.registry.registerDatasetType(DatasetType(
             "promptPreload_metrics",
             dimensions={"instrument", "group", "detector"},
             storageClass="MetricMeasurementBundle",
-            universe=self.butler.dimensions,
+            universe=self.repo.butler.dimensions,
         ))
-        self.butler.put(bundle,
-                        "promptPreload_metrics",
-                        run=runs.get_preload_run(self.instrument, self._deployment, self._day_obs),
-                        instrument=self.instrument.getName(),
-                        detector=self.visit.detector,
-                        group=self.visit.groupId)
+        self.repo.butler.put(bundle,
+                             "promptPreload_metrics",
+                             run=runs.get_preload_run(self.instrument, self._deployment, self._day_obs),
+                             instrument=self.instrument.getName(),
+                             detector=self.visit.detector,
+                             group=self.visit.groupId)
 
     @connect.retry(2, SQL_EXCEPTIONS, wait=repo_retry)
     def _find_pipeline_inputs(self, region):
@@ -901,29 +896,29 @@ class MiddlewareInterface:
         end = start + 3.0 * self.visit.duration * astropy.units.second
         timespan = Timespan(start, end)
 
-        self.butler.registry.registerDatasetType(DatasetType(
+        self.repo.butler.registry.registerDatasetType(DatasetType(
             "regionTimeInfo",
             dimensions={"instrument", "group", "detector"},
             storageClass="RegionTimeInfo",
-            universe=self.butler.dimensions,
+            universe=self.repo.butler.dimensions,
         ))
-        self.butler.put(lsst.pipe.base.utils.RegionTimeInfo(region=region, timespan=timespan),
-                        "regionTimeInfo",
-                        run=runs.get_preload_run(self.instrument, self._deployment, self._day_obs),
-                        instrument=self.instrument.getName(),
-                        detector=self.visit.detector,
-                        group=self.visit.groupId)
+        self.repo.butler.put(lsst.pipe.base.utils.RegionTimeInfo(region=region, timespan=timespan),
+                             "regionTimeInfo",
+                             run=runs.get_preload_run(self.instrument, self._deployment, self._day_obs),
+                             instrument=self.instrument.getName(),
+                             detector=self.visit.detector,
+                             group=self.visit.groupId)
 
     def _prep_collections(self):
         """Pre-register output collections in advance of running the pipeline.
 
         ``self._init_governor_datasets`` must have already been run.
         """
-        self.butler.collections.register(
+        self.repo.butler.collections.register(
             runs.get_preload_run(self.instrument, self._deployment, self._day_obs),
             CollectionType.RUN)
         for pipeline_file in self.get_combined_pipeline_files():
-            self.butler.collections.register(
+            self.repo.butler.collections.register(
                 runs.get_output_run(self.instrument, self._deployment, pipeline_file, self._day_obs),
                 CollectionType.RUN)
 
@@ -1068,10 +1063,10 @@ class MiddlewareInterface:
         angle : `astropy.coordinates.Angle` or `None`
             The observed rotation angle.
         """
-        records = self.butler.query_dimension_records("exposure",
-                                                      instrument=self.instrument.getName(),
-                                                      exposure=exposure,
-                                                      )
+        records = self.repo.butler.query_dimension_records("exposure",
+                                                           instrument=self.instrument.getName(),
+                                                           exposure=exposure,
+                                                           )
         if not records:
             raise ValueError(f"Unknown exposure {exposure}.")
         elif len(records) > 1:
@@ -1125,7 +1120,7 @@ class MiddlewareInterface:
         in_collections : sequence [`str`]
             Collections, usually containing previous outputs, to search (in
             order) when reading pipeline inputs. This list is prepended to the
-            collections in ``self.butler``.
+            collections in ``self.repo.butler``.
         data_ids : `str`
             A query string, in the format of the ``where`` parameter to
             `lsst.daf.butler.query_data_ids`, specifying the data IDs
@@ -1158,9 +1153,8 @@ class MiddlewareInterface:
                 raise InvalidPipelineError(f"Could not load {pipeline_file}.") from e
             output_run = runs.get_output_run(self.instrument, self._deployment, pipeline_file, self._day_obs)
             factory = lsst.pipe.base.TaskFactory()
-            with Butler(butler=self.butler,
-                        collections=[output_run] + in_collections + list(self.butler.collections.defaults),
-                        run=output_run) as exec_butler:
+            all_collections = [output_run] + in_collections + list(self.repo.butler.collections.defaults)
+            with Butler(butler=self.repo.butler, collections=all_collections, run=output_run) as exec_butler:
                 executor = SeparablePipelineExecutor(
                     exec_butler,
                     clobber_output=False,
@@ -1209,7 +1203,7 @@ class MiddlewareInterface:
                     raise PipelineExecutionError(f"Execution failed for {pipeline_file}.") from e
                 finally:
                     # Refresh so that registry queries know the processed products.
-                    self.butler.registry.refresh()
+                    self.repo.butler.registry.refresh()
             break
         else:
             raise NoGoodPipelinesError(f"No {label} pipeline graph could be built.")
@@ -1230,7 +1224,7 @@ class MiddlewareInterface:
         ref : `lsst.daf.butler.DatasetRef`
             A reference to a to-be-written provenance dataset in ``output_run``.
         """
-        query_results = self.butler.query_data_ids(
+        query_results = self.repo.butler.query_data_ids(
             self._provenance_dataset_type.dimensions, where=where, explain=False
         )
         try:
@@ -1292,7 +1286,7 @@ class MiddlewareInterface:
             `True` if changes have been made, `False` if retries are safe.
         """
         # Need dimension records to determine region.
-        data_ids = self.butler.query_data_ids(
+        data_ids = self.repo.butler.query_data_ids(
             ["instrument", "visit", "detector"], where=where, with_dimension_records=True, explain=False
         )
         if len(data_ids) == 1:
@@ -1424,7 +1418,7 @@ class MiddlewareInterface:
             export_patterns = [".*"]
         export_types = set(
             data_type
-            for data_type in self._get_safe_dataset_types(self.butler)
+            for data_type in self._get_safe_dataset_types(self.repo.butler)
             for pattern in export_patterns
             if re.fullmatch(pattern, data_type)
         )
@@ -1456,11 +1450,11 @@ class MiddlewareInterface:
                 with lsst.utils.timer.time_this(_log, msg="upload metrics", level=logging.DEBUG):
                     # Making bundles a collection makes debug log simpler, and it should be short.
                     bundles = list(self._query_datasets_by_storage_class(
-                        self.butler, exposure_ids, output_runs, "MetricMeasurementBundle"))
+                        self.repo.butler, exposure_ids, output_runs, "MetricMeasurementBundle"))
                     for bundle in bundles:
                         try:
                             _log_trace.debug("Uploading %s...", bundle)
-                            dispatcher.dispatchRef(self.butler.get(bundle), bundle)
+                            dispatcher.dispatchRef(self.repo.butler.get(bundle), bundle)
                         except (SasquatchDispatchFailure, SasquatchDispatchPartialFailure):
                             # Retries can get messy with multiple bundles, so just abort.
                             _log.exception("Failed to upload %s to Sasquatch: ", bundle)
@@ -1510,7 +1504,7 @@ class MiddlewareInterface:
             try:
                 datasets = set()
                 for dataset_type in dataset_types:
-                    datasets |= set(self.butler.query_datasets(
+                    datasets |= set(self.repo.butler.query_datasets(
                         dataset_type,
                         collections=in_collections,
                         # in_collections may include other runs, so need to filter.
@@ -1534,7 +1528,7 @@ class MiddlewareInterface:
             # central registry. We need to transfer our exposure/visit dimensions,
             # so handle those manually.
             dimension_records = self._get_dimension_records_to_export(
-                self.butler,
+                self.repo.butler,
                 where="exposure in (exposure_ids)",
                 bind={"exposure_ids": exposure_ids},
                 instrument=self.instrument.getName(),
@@ -1542,7 +1536,9 @@ class MiddlewareInterface:
             )
 
         with lsst.utils.timer.time_this(_log, msg="export_outputs (transfer)", level=logging.DEBUG):
-            transferred = self._butler_writer.transfer_outputs(self.butler, dimension_records, list(datasets))
+            transferred = self._butler_writer.transfer_outputs(self.repo.butler,
+                                                               dimension_records,
+                                                               list(datasets))
             _check_transfer_completion(datasets, transferred, "Uploaded")
 
         return transferred

--- a/python/activator/mw_retries.py
+++ b/python/activator/mw_retries.py
@@ -1,0 +1,44 @@
+# This file is part of prompt_processing.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Shared definitions for retrying Butler I/O operations.
+
+These definitions will need to be updated as Middleware behavior changes.
+"""
+
+
+__all__ = ["repo_retry", "SQL_EXCEPTIONS", "DATASTORE_EXCEPTIONS"]
+
+
+import os
+
+import botocore.exceptions
+import sqlalchemy.exc
+
+
+# TODO: rationalize config options on DM-52695
+# The (jittered) number of seconds to delay retrying connections to the central Butler.
+repo_retry = float(os.environ.get("REPO_RETRY_DELAY", 30))
+
+# TODO: revisit which cases should be retried after DM-50934
+# TODO: catch ButlerConnectionError once it's available
+SQL_EXCEPTIONS = (sqlalchemy.exc.OperationalError, sqlalchemy.exc.InterfaceError)
+DATASTORE_EXCEPTIONS = SQL_EXCEPTIONS + (botocore.exceptions.ClientError, )

--- a/python/shared/run_utils.py
+++ b/python/shared/run_utils.py
@@ -105,8 +105,8 @@ def get_output_run(instrument: lsst.obs.base.Instrument,
     """
     pipeline_name, _ = os.path.splitext(os.path.basename(pipeline_file))
     # Order optimized for S3 bucket -- filter out as many files as soon as possible.
-    output_run = instrument.makeCollectionName("runs", "prompt", f"{date:08d}")
-    return "/".join([output_run, pipeline_name, deployment_id])
+    # Note: get_output_chain is NOT a prefix of the run name
+    return instrument.makeCollectionName("runs", "prompt", f"{date:08d}", pipeline_name, deployment_id)
 
 
 def get_day_obs(time: astropy.time.Time) -> int:

--- a/tests/mock_central_repo.py
+++ b/tests/mock_central_repo.py
@@ -30,6 +30,8 @@ that depend on it will fail.
 __all__ = ["TestRepo"]
 
 
+import os.path
+
 import astropy.coordinates
 import astropy.time
 import astropy.units as u
@@ -49,6 +51,11 @@ class TestRepo:
 
     Should never need to be instantiated.
     """
+    # The directory containing all test data.
+    data_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data")
+    # The location of the test repo itself.
+    repo_dir = os.path.join(data_dir, "central_repo")
+
     # The short name of the instrument used in the test repo.
     instname = "LSSTCam"
     # Full name of the physical filter for the test file.

--- a/tests/test_local_repo.py
+++ b/tests/test_local_repo.py
@@ -27,8 +27,12 @@ import tempfile
 import unittest
 import unittest.mock
 
+import lsst.afw.image as afw_image
 import lsst.daf.butler as daf_butler
+import lsst.daf.butler.tests as butler_tests
+import lsst.obs.base
 
+import shared.run_utils
 import activator.caching
 from activator.local_repo import LocalRepo
 import activator.repo_tracker
@@ -69,6 +73,8 @@ class LocalRepoTest(unittest.TestCase):
 
         self.testbed = LocalRepo(self.local_space.name, self.central_butler, TestRepo.instname)
         self.addCleanup(self.testbed.close)
+
+        self.instrument = lsst.obs.base.Instrument.fromName("LSSTCam", registry=self.central_butler.registry)
 
     def test_init_errors(self):
         with self.assertRaises(OSError):
@@ -202,7 +208,7 @@ class LocalRepoTest(unittest.TestCase):
 
     def test_export_calib_associations_ok(self):
         datasets = self._known_refs(self.central_butler)
-        calib_chain = "LSSTCam/calib"
+        calib_chain = self.instrument.makeCalibrationCollectionName()
         # Preconditions: datasets and calib collections have been transferred
         self.testbed.load_from(self.central_butler, datasets)
         for calib_collection in self.central_butler.collections.query(
@@ -221,7 +227,7 @@ class LocalRepoTest(unittest.TestCase):
 
     def test_export_calib_associations_nodataset(self):
         datasets = self._known_refs(self.central_butler)
-        calib_chain = "LSSTCam/calib"
+        calib_chain = self.instrument.makeCalibrationCollectionName()
         # Precondition: calib collections have been transferred
         for calib_collection in self.central_butler.collections.query(
                 "*", daf_butler.CollectionType.CALIBRATION):
@@ -238,7 +244,7 @@ class LocalRepoTest(unittest.TestCase):
 
     def test_export_calib_associations_nocollection(self):
         datasets = self._known_refs(self.central_butler)
-        calib_chain = "LSSTCam/calib"
+        calib_chain = self.instrument.makeCalibrationCollectionName()
         # Preconditions: datasets
         self.testbed.load_from(self.central_butler, datasets)
         # Failed precondition: calib collections have not been transferred
@@ -285,7 +291,7 @@ class LocalRepoTest(unittest.TestCase):
             self._check_collection(child, self.central_butler.collections, test_butler.collections)
 
     def test_sync_collections_2level(self):
-        target = "LSSTCam/defaults"
+        target = self.instrument.makeUmbrellaCollectionName()
         self.testbed.sync_collections(self.central_butler, target)
 
         test_butler = daf_butler.Butler(self.testbed._repo.name)
@@ -306,6 +312,108 @@ class LocalRepoTest(unittest.TestCase):
         test_butler = daf_butler.Butler(self.testbed._repo.name)
         with self.assertRaises(daf_butler.MissingCollectionError):
             test_butler.collections.get_info(target)
+
+    def test_clean_empty(self):
+        # Should be a no-op
+        self.testbed.clean()
+
+    def test_clean_outputs(self):
+        target = shared.run_utils.get_output_run(
+            self.instrument, "test-deployment", "Pipeline.yaml", 20260427)
+
+        test_butler = daf_butler.Butler(self.testbed._repo.name, writeable=True)
+        test_butler.registry.registerDatasetType(daf_butler.DatasetType(
+            "initial_pvi", {"instrument", "visit", "detector"}, "ExposureF", universe=test_butler.dimensions
+        ))
+        butler_tests.addDataIdValue(test_butler, "visit", 101)
+        test_butler.collections.register(target)
+        pvi = afw_image.ExposureF(10, 10)
+        test_butler.put(pvi,
+                        "initial_pvi",
+                        {"instrument": "LSSTCam", "visit": 101, "detector": 42},
+                        run=target,
+                        )
+        self.assertEqual(len(test_butler.query_datasets("initial_pvi", collections=target,
+                                                        find_first=False, explain=False)),
+                         1)
+
+        self.testbed.clean()
+        self.assertEqual(len(test_butler.query_datasets("initial_pvi", collections=target,
+                                                        find_first=False, explain=False)),
+                         0)
+
+    def test_clean_raws(self):
+        target = self.instrument.makeDefaultRawIngestRunName()
+
+        # Not a proper ingest, but should be good enough
+        test_butler = daf_butler.Butler(self.testbed._repo.name, writeable=True)
+        test_butler.registry.registerDatasetType(daf_butler.DatasetType(
+            "raw", {"instrument", "exposure", "detector"}, "ExposureF", universe=test_butler.dimensions
+        ))
+        butler_tests.addDataIdValue(test_butler, "exposure", 42)
+        test_butler.collections.register(target)
+        raw = afw_image.ExposureF(10, 10)
+        test_butler.put(raw,
+                        "raw",
+                        {"instrument": "LSSTCam", "exposure": 42, "detector": 0},
+                        run=target,
+                        )
+        self.assertEqual(
+            len(test_butler.query_datasets("raw", collections=target, find_first=False, explain=False)),
+            1)
+
+        self.testbed.clean()
+        self.assertEqual(
+            len(test_butler.query_datasets("raw", collections=target, find_first=False, explain=False)),
+            0)
+
+    def test_clean_cached_evict(self):
+        datasets = self._known_refs(self.central_butler)
+        # Don't use load_from, because it should guarantee there are no excess cacheable datasets
+        self.testbed.butler.transfer_from(self.central_butler, datasets,
+                                          register_dataset_types=True, transfer_dimensions=True)
+        self.assertEqual(len(self.testbed._cache), 0)
+
+        test_butler = daf_butler.Butler(self.testbed._repo.name)
+        self.assertGreater(
+            len(test_butler.query_datasets("bias", collections="*", find_first=False, explain=False)),
+            0)
+
+        # Nothing is cached, so everything should be removed
+        self.testbed.clean()
+        self.assertEqual(
+            len(test_butler.query_datasets("bias", collections="*", find_first=False, explain=False)),
+            0)
+
+    def test_clean_cached_keep(self):
+        datasets = self._known_refs(self.central_butler)
+        self.testbed.load_from(self.central_butler, datasets)
+
+        test_butler = daf_butler.Butler(self.testbed._repo.name)
+        cached_biases = test_butler.query_datasets("bias", collections="*", find_first=False, explain=False)
+        self.assertGreater(len(cached_biases), 0)
+
+        # repo should already be in sync with the cache
+        self.testbed.clean()
+        self.assertEqual(
+            set(test_butler.query_datasets("bias", collections="*", find_first=False, explain=False)),
+            set(cached_biases))
+
+    def test_clean_uncached(self):
+        datasets = self._known_refs(self.central_butler)
+        self.testbed.load_from(self.central_butler, datasets)
+
+        test_butler = daf_butler.Butler(self.testbed._repo.name)
+        self.assertGreater(
+            len(test_butler.query_datasets("template_coadd", collections="*",
+                                           find_first=False, explain=False)),
+            0)
+
+        self.testbed.clean()
+        self.assertEqual(
+            len(test_butler.query_datasets("template_coadd", collections="*",
+                                           find_first=False, explain=False)),
+            0)
 
     def test_butler(self):
         # Butler is a tagged class, so the only way to test writeability is to

--- a/tests/test_local_repo.py
+++ b/tests/test_local_repo.py
@@ -1,0 +1,261 @@
+# This file is part of prompt_processing.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
+import os
+import os.path
+import random
+import tempfile
+import unittest
+import unittest.mock
+
+import lsst.daf.butler as daf_butler
+
+import activator.caching
+from activator.local_repo import LocalRepo
+import activator.repo_tracker
+
+from mock_central_repo import TestRepo
+
+
+class LocalRepoTest(unittest.TestCase):
+    data_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data")
+    central_repo = os.path.join(data_dir, "central_repo")
+
+    def _known_refs(self, butler):
+        """Identify the loadable datasets in the test repo.
+
+        Parameters
+        ----------
+        butler : `lsst.daf.butler.Butler`
+            A Butler that serves as the source for the refs.
+
+        Returns
+        -------
+        refs : set [`lsst.daf.butler.DatasetRef`]
+            The datasets suitable for preload emulation tests.
+        """
+        types = {"camera", "skyMap", "bias", "flat", "pretrainedModelPackage", "template_coadd",
+                 }
+        return set(butler.query_all_datasets(collections="*", name=types, find_first=False))
+
+    def setUp(self):
+        # Reproducible across Python upgrades
+        random.seed(hash(self.id()), version=2)
+
+        self.central_butler = daf_butler.Butler(self.central_repo, writeable=False, inferDefaults=False)
+        self.addCleanup(self.central_butler.close)
+        self.local_space = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        # TemporaryDirectory warns on leaks
+        self.addCleanup(self.local_space.cleanup)
+
+        self.testbed = LocalRepo(self.local_space.name, self.central_butler, TestRepo.instname)
+        self.addCleanup(self.testbed.close)
+
+    def test_init_errors(self):
+        with self.assertRaises(OSError):
+            LocalRepo("/not/a/real/path", self.central_butler, TestRepo.instname)
+        with self.assertRaises(ValueError):
+            LocalRepo(self.local_space.name, self.central_butler, "NotACam")
+
+    def test_repo(self):
+        # Is self.local_space a prefix of self.testbed._repo?
+        self.assertEqual(os.path.commonpath([self.testbed._repo.name, self.local_space.name]),
+                         self.local_space.name)
+
+    def test_close(self):
+        repo_dir = self.testbed._repo.name
+        self.assertTrue(os.path.exists(repo_dir))
+        self.testbed.close()
+        self.assertFalse(os.path.exists(repo_dir))
+        with self.assertRaises(RuntimeError):
+            self.testbed.butler
+        # Should be idempotent
+        self.testbed.close()
+        self.assertFalse(os.path.exists(repo_dir))
+        with self.assertRaises(RuntimeError):
+            self.testbed.butler
+
+    def _check_load(self, butler, expected, exclusive=False):
+        """Test that the local repo has the expected data.
+
+        Parameters
+        ----------
+        butler : `lsst.daf.butler.Butler`
+            The Butler to use for local repo queries.
+        expected : set [`lsst.daf.butler.DatasetRef`]
+            The datasets that should be present.
+        exclusive : boolean, optional
+            If set, it's an error for the repo to contain datasets other than
+            ``expected``.
+        """
+        all_datasets = set(butler.query_all_datasets("*", find_first=False))
+        if exclusive:
+            self.assertEqual(all_datasets, expected)
+        else:
+            self.assertGreaterEqual(all_datasets, expected)
+
+    def test_load_from_clean(self):
+        datasets = self._known_refs(self.central_butler)
+        present = set(self.testbed.load_from(self.central_butler, datasets))
+        self.assertEqual(present, datasets)
+        self._check_load(daf_butler.Butler(self.testbed._repo.name), datasets, exclusive=True)
+
+    def test_load_from_partial(self):
+        all_datasets = self._known_refs(self.central_butler)
+        prior_datasets = set(random.sample(list(all_datasets), len(all_datasets) // 2))
+
+        self.testbed.load_from(self.central_butler, prior_datasets)
+        self._check_load(daf_butler.Butler(self.testbed._repo.name), prior_datasets, exclusive=True)
+
+        extra = all_datasets - prior_datasets
+        with unittest.mock.patch.object(self.testbed.butler,
+                                        "transfer_from",
+                                        wraps=self.testbed.butler.transfer_from,
+                                        ) as transfer:
+            present = set(self.testbed.load_from(self.central_butler, all_datasets))
+            transfer.assert_called_once()
+            # No unnecessary transfers
+            self.assertEqual(transfer.call_args.args[1], extra)
+            self.assertEqual(present, all_datasets)
+        self._check_load(daf_butler.Butler(self.testbed._repo.name), all_datasets, exclusive=True)
+
+    def test_load_from_missing(self):
+        datasets = self._known_refs(self.central_butler)
+        absent = list(datasets)[0].replace(id=None, run="fake_run")
+
+        with unittest.mock.patch.object(self.testbed.butler,
+                                        "transfer_from",
+                                        wraps=self.testbed.butler.transfer_from,
+                                        ) as transfer:
+            present = set(self.testbed.load_from(self.central_butler, datasets | {absent}))
+            transfer.assert_called_once()
+            # Attempted to transfer `absent`
+            self.assertEqual(transfer.call_args.args[1], datasets | {absent})
+            self.assertEqual(present, datasets)
+        self._check_load(daf_butler.Butler(self.testbed._repo.name), datasets, exclusive=True)
+
+    def test_load_from_exclude(self):
+        datasets = self._known_refs(self.central_butler)
+        # For best test power, these should be datasets that are otherwise cacheable
+        missing_runs = ["skymaps", "pretrained_models/dummy"]
+        uncached = {ref for ref in datasets if ref.run in missing_runs}
+        self.assertGreater(len(uncached), 0)
+
+        with unittest.mock.patch.object(self.testbed.butler,
+                                        "transfer_from",
+                                        wraps=self.testbed.butler.transfer_from,
+                                        ) as transfer:
+            present = set(self.testbed.load_from(self.central_butler, datasets, no_cache_runs=missing_runs))
+            transfer.assert_called_once()
+            # Still attempted to transfer uncachable datasets
+            self.assertEqual(transfer.call_args.args[1], datasets)
+            self.assertEqual(present, datasets)
+        self._check_load(daf_butler.Butler(self.testbed._repo.name), datasets, exclusive=True)
+        # Don't see a cleaner way to check if a dataset is cache-managed
+        for ref in uncached:
+            self.assertNotIn(ref, self.testbed._cache)
+
+    def test_load_from_overflow(self):
+        all_datasets = self._known_refs(self.central_butler)
+        grouped_datasets = daf_butler.DatasetRef.groupByType(all_datasets)
+        # Assumed by cache retention test
+        singleton_type = "pretrainedModelPackage"
+        self.assertEqual(len(grouped_datasets[singleton_type]), 1)
+
+        # Don't see a cleaner way of doing this, given that I don't want
+        # a cache dependency in the API
+        cache_size = 1
+        mock_cache = activator.caching.DatasetCache(cache_size)
+        with unittest.mock.patch.object(self.testbed, "_cache", wraps=mock_cache):
+            # LocalRepo may have safeguards against overloading the cache in one sitting
+            for i in range(cache_size + 1):
+                generation = {refs[i] for refs in grouped_datasets.values() if i < len(refs)}
+                present = set(self.testbed.load_from(self.central_butler, generation))
+                self.assertEqual(present, generation)
+            test_butler = daf_butler.Butler(self.testbed._repo.name)
+            # Non-exclusive: final generation probably didn't update all dataset types
+            self._check_load(test_butler, generation)
+            # Have any datasets actually been evicted?
+            with self.assertRaises(self.failureException):
+                self._check_load(test_butler, all_datasets)
+            # Are old datasets kept if there's no need to evict them?
+            self._check_load(test_butler, set(grouped_datasets[singleton_type]))
+
+    def test_export_calib_associations_ok(self):
+        datasets = self._known_refs(self.central_butler)
+        calib_chain = "LSSTCam/calib"
+        # Preconditions: datasets and calib collections have been transferred
+        self.testbed.load_from(self.central_butler, datasets)
+        for calib_collection in self.central_butler.collections.query(
+                "*", daf_butler.CollectionType.CALIBRATION):
+            self.testbed.butler.collections.register(calib_collection, daf_butler.CollectionType.CALIBRATION)
+            self.testbed.butler.collections.extend_chain(calib_chain, calib_collection)
+
+        calibs = {ref for ref in datasets if ref.datasetType.isCalibration()}
+        self.testbed.export_calib_associations(self.central_butler, calib_chain, calibs)
+
+        test_butler = daf_butler.Butler(self.testbed._repo.name)
+        for calib in calibs:
+            # Search for the calib *through the collection* (we know the dataset itself exists)
+            self.assertTrue(test_butler.exists(calib.datasetType, calib.dataId, collections=calib_chain),
+                            msg=f"{calib} not found in {calib_chain}")
+
+    def test_export_calib_associations_nodataset(self):
+        datasets = self._known_refs(self.central_butler)
+        calib_chain = "LSSTCam/calib"
+        # Precondition: calib collections have been transferred
+        for calib_collection in self.central_butler.collections.query(
+                "*", daf_butler.CollectionType.CALIBRATION):
+            self.testbed.butler.collections.register(calib_collection, daf_butler.CollectionType.CALIBRATION)
+            self.testbed.butler.collections.extend_chain(calib_chain, calib_collection)
+        # Failed precondition: datasets not transferred
+        # Define dataset types to eliminate that as a variable
+        for ref in datasets:
+            self.testbed.butler.registry.registerDatasetType(ref.datasetType)
+
+        calibs = {ref for ref in datasets if ref.datasetType.isCalibration()}
+        with self.assertRaises(ValueError):
+            self.testbed.export_calib_associations(self.central_butler, calib_chain, calibs)
+
+    def test_export_calib_associations_nocollection(self):
+        datasets = self._known_refs(self.central_butler)
+        calib_chain = "LSSTCam/calib"
+        # Preconditions: datasets
+        self.testbed.load_from(self.central_butler, datasets)
+        # Failed precondition: calib collections have not been transferred
+
+        calibs = {ref for ref in datasets if ref.datasetType.isCalibration()}
+        with self.assertRaises(daf_butler.MissingCollectionError):
+            self.testbed.export_calib_associations(self.central_butler, calib_chain, calibs)
+
+    def test_butler(self):
+        # Butler is a tagged class, so the only way to test writeability is to
+        # actually write something
+        test_type = daf_butler.DatasetType(
+            "TestData",
+            dimensions=set(),
+            storageClass="StructuredDataDict",
+            universe=self.testbed.butler.dimensions,
+        )
+        self.testbed.butler.registry.registerDatasetType(test_type)
+        self.testbed.butler.collections.register("test_run")
+        self.testbed.butler.put({"foo": "bar", "answer": 42}, test_type, {}, run="test_run")

--- a/tests/test_local_repo.py
+++ b/tests/test_local_repo.py
@@ -247,6 +247,66 @@ class LocalRepoTest(unittest.TestCase):
         with self.assertRaises(daf_butler.MissingCollectionError):
             self.testbed.export_calib_associations(self.central_butler, calib_chain, calibs)
 
+    def _check_collection(self, collection, src, dest):
+        """Test whether a collection exists and has the expected properties.
+
+        Parameters
+        ----------
+        collection : `str`
+            The collection to test.
+        src : `lsst.daf.butler.ButlerCollections`
+            The source of the collection, which serves as the test oracle.
+        dest : `lsst.daf.butler.ButlerCollections`
+            The destination in which the collection should be reproduced from `src`.
+        """
+        src_info = src.get_info(collection, include_parents=False, include_summary=False)
+        try:
+            dest_info = dest.get_info(collection, include_parents=False, include_summary=False)
+        except daf_butler.MissingCollectionError:
+            self.fail(f"{collection} does not exist in destination repo.")
+        # Tests name, type, doc, and children
+        self.assertEqual(dest_info, src_info)
+
+    def test_sync_collections_single(self):
+        # Not one of the standard collections recognized by obs.base.Instrument
+        target = "skymaps"
+        self.testbed.sync_collections(self.central_butler, target)
+
+        test_butler = daf_butler.Butler(self.testbed._repo.name)
+        self._check_collection(target, self.central_butler.collections, test_butler.collections)
+
+    def test_sync_collections_1level(self):
+        target = "pretrained_models"
+        self.testbed.sync_collections(self.central_butler, target)
+
+        test_butler = daf_butler.Butler(self.testbed._repo.name)
+        self._check_collection(target, self.central_butler.collections, test_butler.collections)
+        for child in self.central_butler.collections.query(target, include_chains=True):
+            self._check_collection(child, self.central_butler.collections, test_butler.collections)
+
+    def test_sync_collections_2level(self):
+        target = "LSSTCam/defaults"
+        self.testbed.sync_collections(self.central_butler, target)
+
+        test_butler = daf_butler.Butler(self.testbed._repo.name)
+        self._check_collection(target, self.central_butler.collections, test_butler.collections)
+        for child in self.central_butler.collections.get_info(target).children:
+            self._check_collection(child, self.central_butler.collections, test_butler.collections)
+            if self.central_butler.collections.get_info(child).type == daf_butler.CollectionType.CHAINED:
+                for grandchild in self.central_butler.collections.get_info(child).children:
+                    self._check_collection(grandchild,
+                                           self.central_butler.collections,
+                                           test_butler.collections)
+
+    def test_sync_collections_missing(self):
+        target = "DoesNotExist"
+        with self.assertRaises(daf_butler.MissingCollectionError):
+            self.testbed.sync_collections(self.central_butler, target)
+
+        test_butler = daf_butler.Butler(self.testbed._repo.name)
+        with self.assertRaises(daf_butler.MissingCollectionError):
+            test_butler.collections.get_info(target)
+
     def test_butler(self):
         # Butler is a tagged class, so the only way to test writeability is to
         # actually write something

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -21,7 +21,6 @@
 
 import dataclasses
 import datetime
-import functools
 import itertools
 import tempfile
 import os.path
@@ -53,7 +52,7 @@ from activator.caching import DatasetCache
 from activator.exception import NonRetriableError, NoGoodPipelinesError, PipelineExecutionError
 from activator.middleware_interface import get_central_butler, make_local_repo, \
     _get_sasquatch_dispatcher, MiddlewareInterface, DirectButlerWriter, \
-    _filter_datasets, _find_datasets_in_repo, _generic_query, _MissingDatasetError
+    _find_datasets_in_repo, _generic_query
 from shared.config import PipelinesConfig
 from shared.run_utils import get_output_run
 from shared.visit import FannedOutVisit
@@ -1058,118 +1057,6 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                                       {"SASQUATCH_URL": "https://localhost/dummy",
                                        }):
             self.assertIsNotNone(_get_sasquatch_dispatcher())
-
-    def test_filter_datasets(self):
-        """Test that _filter_datasets provides the correct values.
-        """
-        # Much easier to create DatasetRefs with a real repo.
-        data1 = self._make_expanded_ref(self.read_butler, "bias", {"instrument": "LSSTCam", "detector": 5},
-                                        "dummy")
-        data2 = self._make_expanded_ref(self.read_butler, "bias", {"instrument": "LSSTCam", "detector": 0},
-                                        "dummy")
-        data3 = self._make_expanded_ref(self.read_butler, "bias", {"instrument": "LSSTCam", "detector": 1},
-                                        "dummy")
-
-        combinations = [{data1, data2}, {data1, data2, data3}]
-        src_butler = unittest.mock.Mock()
-        existing_butler = unittest.mock.Mock()
-        # Case where src is empty now covered in test_filter_datasets_nosrc.
-        for src, existing in itertools.product(combinations, [set()] + combinations):
-            diff = src - existing
-
-            def query(butler, _label):
-                if butler is src_butler:
-                    return src
-                elif butler is existing_butler:
-                    return existing
-                else:
-                    raise ValueError("Unknown butler!")
-
-            with (self.subTest(src=sorted(ref.dataId["detector"] for ref in src),
-                               existing=sorted(ref.dataId["detector"] for ref in existing)),
-                  unittest.mock.patch.object(existing_butler, "get_many_datasets", return_value=existing),
-                  ):
-                result = set(_filter_datasets(src_butler, existing_butler, query))
-                self.assertEqual(result, diff)
-
-    def test_filter_datasets_nosrc(self):
-        """Test that _filter_datasets reports if the datasets are missing from
-        the source repository, regardless of whether they are present in the
-        destination repository.
-        """
-        # Much easier to create DatasetRefs with a real repo.
-        data1 = self._make_expanded_ref(self.read_butler, "bias", {"instrument": "LSSTCam", "detector": 1},
-                                        "dummy")
-
-        src_butler = unittest.mock.Mock()
-        existing_butler = unittest.mock.Mock()
-        for existing in [set(), {data1}]:
-
-            def query(butler, _label):
-                if butler is src_butler:
-                    return set()
-                elif butler is existing_butler:
-                    return existing
-                else:
-                    raise ValueError("Unknown butler!")
-
-            with (self.subTest(existing=sorted(ref.dataId["detector"] for ref in existing)),
-                  unittest.mock.patch.object(existing_butler, "get_many_datasets", return_value=existing),
-                  ):
-                with self.assertRaises(_MissingDatasetError):
-                    _filter_datasets(src_butler, existing_butler, query)
-
-    def test_filter_datasets_all_callback(self):
-        """Test that _filter_datasets passes the correct values to its callback.
-        """
-        def test_function(expected, incoming):
-            self.assertEqual(expected, incoming)
-
-        # Much easier to create DatasetRefs with a real repo.
-        data1 = self._make_expanded_ref(self.read_butler, "bias", {"instrument": "LSSTCam", "detector": 5},
-                                        "dummy")
-        data2 = self._make_expanded_ref(self.read_butler, "bias", {"instrument": "LSSTCam", "detector": 0},
-                                        "dummy")
-        data3 = self._make_expanded_ref(self.read_butler, "bias", {"instrument": "LSSTCam", "detector": 1},
-                                        "dummy")
-
-        combinations = [{data1, data2}, {data1, data2, data3}]
-        src_butler = unittest.mock.Mock()
-        existing_butler = unittest.mock.Mock()
-        # Case where src is empty covered below.
-        for src, existing in itertools.product(combinations, [set()] + combinations):
-            def query(butler, _label):
-                if butler is src_butler:
-                    return src
-                elif butler is existing_butler:
-                    return existing
-                else:
-                    raise ValueError("Unknown butler!")
-
-            with (self.subTest(src=sorted(ref.dataId["detector"] for ref in src),
-                               existing=sorted(ref.dataId["detector"] for ref in existing)),
-                  unittest.mock.patch.object(existing_butler, "get_many_datasets", return_value=existing),
-                  ):
-                _filter_datasets(src_butler, existing_butler, query,
-                                 all_callback=functools.partial(test_function, src))
-
-        # Should not call
-
-        def non_callable(_):
-            self.fail("Callback called during _MissingDatasetError.")
-
-        for existing in [set()] + combinations:
-            def query(butler, _label):
-                if butler is src_butler:
-                    return set()
-                elif butler is existing_butler:
-                    return existing
-                else:
-                    raise ValueError("Unknown butler!")
-
-            with self.subTest(existing=sorted(ref.dataId["detector"] for ref in existing)):
-                with self.assertRaises(_MissingDatasetError):
-                    _filter_datasets(src_butler, existing_butler, query, all_callback=non_callable)
 
     def test_find_datasets_in_repo(self):
         # Much easier to create DatasetRefs with a real repo.

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -21,7 +21,6 @@
 
 import dataclasses
 import datetime
-import itertools
 import tempfile
 import os.path
 import unittest
@@ -40,7 +39,7 @@ import lsst.afw.image
 import lsst.afw.table
 from lsst.dax.apdb import ApdbSql
 from lsst.daf.butler import (
-    Butler, CollectionType, DataCoordinate, DatasetType, DimensionUniverse, EmptyQueryResultError
+    Butler, CollectionType, DatasetType, DimensionUniverse, EmptyQueryResultError
 )
 import lsst.daf.butler.tests as butler_tests
 from lsst.pipe.base.quantum_graph import PredictedQuantumGraph
@@ -50,9 +49,9 @@ import lsst.sphgeom
 
 from activator.caching import DatasetCache
 from activator.exception import NonRetriableError, NoGoodPipelinesError, PipelineExecutionError
-from activator.middleware_interface import get_central_butler, make_local_repo, \
-    _get_sasquatch_dispatcher, MiddlewareInterface, DirectButlerWriter, \
-    _find_datasets_in_repo
+from activator.local_repo import LocalRepo
+from activator.middleware_interface import get_central_butler, \
+    _get_sasquatch_dispatcher, MiddlewareInterface, DirectButlerWriter
 from shared.config import PipelinesConfig
 from shared.run_utils import get_output_run
 from shared.visit import FannedOutVisit
@@ -108,6 +107,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         self.data_dir = TestRepo.data_dir
         self.central_repo = TestRepo.repo_dir
         self.umbrella = f"{TestRepo.instname}/defaults"
+
         self.read_butler = Butler(self.central_repo,
                                   writeable=False,
                                   inferDefaults=False)
@@ -117,11 +117,14 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                                    inferDefaults=False)
         self.addCleanup(self.write_butler.close)
         self.input_data = os.path.join(self.data_dir, "input_data")
-        self.local_repo = make_local_repo(tempfile.gettempdir(), self.read_butler, TestRepo.instname)
-        self.local_cache = DatasetCache(3)
-        self.addCleanup(self.local_repo.cleanup)  # TemporaryDirectory warns on leaks
+        with unittest.mock.patch("activator.local_repo.LocalRepo._make_local_cache",
+                                 return_value=DatasetCache(3)):
+            self.local_repo = LocalRepo(tempfile.gettempdir(), self.read_butler, TestRepo.instname)
+        self.addCleanup(self.local_repo.close)
 
-        config = ApdbSql.init_database(db_url=f"sqlite:///{self.local_repo.name}/apdb.db")
+        apdb_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        self.addCleanup(apdb_dir.cleanup)
+        config = ApdbSql.init_database(db_url=f"sqlite:///{apdb_dir.name}/apdb.db")
         config_file = tempfile.NamedTemporaryFile(suffix=".py")
         self.addCleanup(config_file.close)
         config.save(config_file.name)
@@ -171,9 +174,8 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                                              # Use empty preprocessing to avoid slowing down tests
                                              # with real pipelines (adds 20s)
                                              pre_pipelines_empty, pipelines, TestRepo.skymap_name,
-                                             self.local_repo.name, self.local_cache,
+                                             self.local_repo,
                                              prefix="file://")
-        self.addCleanup(self.interface.close)
 
     def test_get_butler(self):
         for butler in [get_central_butler(self.central_repo, "lsst.obs.lsst.LsstCam", writeable=True),
@@ -202,18 +204,6 @@ class MiddlewareInterfaceTest(unittest.TestCase):
             finally:
                 butler.close()
 
-    def test_make_local_repo(self):
-        for inst in [TestRepo.instname, "lsst.obs.lsst.LsstCam"]:
-            with (Butler(self.central_repo) as central_butler,
-                  make_local_repo(tempfile.gettempdir(), central_butler, inst) as repo_dir):
-                self.assertTrue(os.path.exists(repo_dir))
-                with Butler(repo_dir) as butler:
-                    self.assertEqual([x.dataId for x in butler.query_dimension_records("instrument")],
-                                     [DataCoordinate.standardize({"instrument": TestRepo.instname},
-                                                                 universe=butler.dimensions)])
-                    self.assertIn(f"{TestRepo.instname}/defaults", butler.collections.query("*"))
-            self.assertFalse(os.path.exists(repo_dir))
-
     def test_init(self):
         """Basic tests of the initialized interface object.
         """
@@ -225,13 +215,6 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         # Check that the ingester is properly configured.
         self.assertEqual(self.interface.rawIngestTask.config.failFast, True)
         self.assertEqual(self.interface.rawIngestTask.config.transfer, "copy")
-
-    def test_close(self):
-        self.interface.close()
-        self.assertTrue(self.interface._closed)
-        # Should be idempotent
-        self.interface.close()
-        self.assertTrue(self.interface._closed)
 
     def _check_imports(self, butler, group, detector, expected_shards, have_filter=True, have_spatial=True):
         """Test that the butler has the expected supporting data.
@@ -451,18 +434,15 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         second_interface = MiddlewareInterface(self.read_butler, butler_writer,
                                                self.input_data, second_visit,
                                                pre_pipelines_empty, pipelines, TestRepo.skymap_name,
-                                               self.local_repo.name, self.local_cache,
+                                               self.local_repo,
                                                prefix="file://")
-        try:
-            with unittest.mock.patch(
-                "activator.middleware_interface.MiddlewareInterface._run_preprocessing"
-            ) as mock_pre:
-                second_interface.prep_butler()
-            expected_shards = {180002, 180177}
-            self._check_imports(second_interface.butler, group="2", detector=90,
-                                expected_shards=expected_shards)
-        finally:
-            second_interface.close()
+        with unittest.mock.patch(
+            "activator.middleware_interface.MiddlewareInterface._run_preprocessing"
+        ) as mock_pre:
+            second_interface.prep_butler()
+        expected_shards = {180002, 180177}
+        self._check_imports(second_interface.butler, group="2", detector=90,
+                            expected_shards=expected_shards)
         # Hard to test actual pipeline output, so just check we're calling it
         mock_pre.assert_called_once()
 
@@ -478,18 +458,15 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         third_interface = MiddlewareInterface(self.read_butler, butler_writer,
                                               self.input_data, third_visit,
                                               pre_pipelines_empty, pipelines, TestRepo.skymap_name,
-                                              self.local_repo.name, self.local_cache,
+                                              self.local_repo,
                                               prefix="file://")
-        try:
-            with unittest.mock.patch(
-                "activator.middleware_interface.MiddlewareInterface._run_preprocessing"
-            ) as mock_pre:
-                third_interface.prep_butler()
-            expected_shards.update({180002, 180177})
-            self._check_imports(third_interface.butler, group="3", detector=91,
-                                expected_shards=expected_shards)
-        finally:
-            third_interface.close()
+        with unittest.mock.patch(
+            "activator.middleware_interface.MiddlewareInterface._run_preprocessing"
+        ) as mock_pre:
+            third_interface.prep_butler()
+        expected_shards.update({180002, 180177})
+        self._check_imports(third_interface.butler, group="3", detector=91,
+                            expected_shards=expected_shards)
         # Hard to test actual pipeline output, so just check we're calling it
         mock_pre.assert_called_once()
 
@@ -981,7 +958,8 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         out_collection = get_output_run(self.interface.instrument, self.deploy_id,
                                         "ApPipe.yaml", self.interface._day_obs)
         butler.collections.register(out_collection, CollectionType.RUN)
-        calib_collection = self.interface.instrument.makeCalibrationCollectionName()
+        # Avoid conflict with the original calib chain
+        calib_collection = self.interface.instrument.makeCalibrationCollectionName("dummy")
         butler.collections.register(calib_collection, CollectionType.RUN)
         chain = self.interface.instrument.makeUmbrellaCollectionName()
         butler.collections.register(chain, CollectionType.CHAINED)
@@ -995,7 +973,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         bias_3 = butler.put(exp, "bias", calib_data_id_3, run=calib_collection)
         bias_4 = butler.put(exp, "bias", calib_data_id_4, run=calib_collection)
         with self.assertWarns(RuntimeWarning):  # Deliberately overflowing cache
-            self.local_cache.update([bias_1, bias_2, bias_3, bias_4, ])
+            self.local_repo._cache.update([bias_1, bias_2, bias_3, bias_4, ])
         self._assert_in_collection(butler, "*", "raw", raw_data_id)
         self._assert_in_collection(butler, "*", "src", processed_data_id)
         self._assert_in_collection(butler, "*", "calexp", processed_data_id)
@@ -1008,9 +986,9 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         self._assert_not_in_collection(butler, "*", "src", processed_data_id)
         self._assert_not_in_collection(butler, "*", "calexp", processed_data_id)
         # Default cache has size 2, so one of the biases should have been removed
-        self._check_cache_vs_collection(butler, self.local_cache, bias_1)
-        self._check_cache_vs_collection(butler, self.local_cache, bias_2)
-        self._check_cache_vs_collection(butler, self.local_cache, bias_3)
+        self._check_cache_vs_collection(butler, self.local_repo._cache, bias_1)
+        self._check_cache_vs_collection(butler, self.local_repo._cache, bias_2)
+        self._check_cache_vs_collection(butler, self.local_repo._cache, bias_3)
 
     def _check_cache_vs_collection(self, butler, cache, ref):
         if ref in cache:
@@ -1057,28 +1035,6 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                                       {"SASQUATCH_URL": "https://localhost/dummy",
                                        }):
             self.assertIsNotNone(_get_sasquatch_dispatcher())
-
-    def test_find_datasets_in_repo(self):
-        # Much easier to create DatasetRefs with a real repo.
-        data1 = self._make_expanded_ref(self.read_butler, "bias", {"instrument": "LSSTCam", "detector": 5},
-                                        "dummy")
-        data2 = self._make_expanded_ref(self.read_butler, "bias", {"instrument": "LSSTCam", "detector": 0},
-                                        "dummy")
-        data3 = self._make_expanded_ref(self.read_butler, "bias", {"instrument": "LSSTCam", "detector": 1},
-                                        "dummy")
-
-        combinations = [set(), {data1, data2}, {data1, data2, data3}]
-        existing_butler = unittest.mock.Mock()
-        for src, existing in itertools.product(combinations, combinations):
-            with (self.subTest(src=sorted(ref.dataId["detector"] for ref in src),
-                               existing=sorted(ref.dataId["detector"] for ref in existing)),
-                  # TODO: find an efficient way to use real Butler, otherwise the test is trivial
-                  unittest.mock.patch.object(existing_butler, "get_many_datasets",
-                                             return_value=(existing & src)),
-                  ):
-                found = set(_find_datasets_in_repo(existing_butler, src))
-                self.assertLessEqual(found, src)
-                self.assertEqual(found, existing & src)
 
 
 class MiddlewareInterfaceWriteableTest(unittest.TestCase):
@@ -1141,16 +1097,18 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
         self.addCleanup(self.write_butler.close)
         self.input_data = os.path.join(TestRepo.data_dir, "input_data")
 
-        local_repo = make_local_repo(tempfile.gettempdir(), read_butler, TestRepo.instname)
-        self.local_cache = DatasetCache(2)
-        second_local_repo = make_local_repo(tempfile.gettempdir(), read_butler, TestRepo.instname)
-        self.second_local_cache = DatasetCache(2)
-        # TemporaryDirectory warns on leaks; addCleanup also keeps the TD from
-        # getting garbage-collected.
-        self.addCleanup(tempfile.TemporaryDirectory.cleanup, local_repo)
-        self.addCleanup(tempfile.TemporaryDirectory.cleanup, second_local_repo)
+        with unittest.mock.patch("activator.local_repo.LocalRepo._make_local_cache",
+                                 return_value=DatasetCache(2)):
+            local_repo = LocalRepo(tempfile.gettempdir(), read_butler, TestRepo.instname)
+        self.addCleanup(local_repo.close)
+        with unittest.mock.patch("activator.local_repo.LocalRepo._make_local_cache",
+                                 return_value=DatasetCache(2)):
+            second_local_repo = LocalRepo(tempfile.gettempdir(), read_butler, TestRepo.instname)
+        self.addCleanup(second_local_repo.close)
 
-        config = ApdbSql.init_database(db_url=f"sqlite:///{local_repo.name}/apdb.db")
+        apdb_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
+        self.addCleanup(apdb_dir.cleanup)
+        config = ApdbSql.init_database(db_url=f"sqlite:///{apdb_dir.name}/apdb.db")
         config_file = tempfile.NamedTemporaryFile(suffix=".py")
         self.addCleanup(config_file.close)
         config.save(config_file.name)
@@ -1199,9 +1157,8 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
         butler_writer = DirectButlerWriter(self.write_butler)
         self.interface = MiddlewareInterface(read_butler, butler_writer, self.input_data, self.next_visit,
                                              pre_pipelines_full, pipelines, TestRepo.skymap_name,
-                                             local_repo.name, self.local_cache,
+                                             local_repo,
                                              prefix="file://")
-        self.addCleanup(self.interface.close)
         with unittest.mock.patch("activator.middleware_interface.MiddlewareInterface._run_preprocessing"):
             self.interface.prep_butler()
         filename = "fakeRawImage.fits"
@@ -1222,8 +1179,7 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
                                      for k, v in self.second_data_id.required.items()}
         self.second_interface = MiddlewareInterface(
             read_butler, butler_writer, self.input_data, self.second_visit, pre_pipelines_full, pipelines,
-            TestRepo.skymap_name, second_local_repo.name, self.second_local_cache, prefix="file://")
-        self.addCleanup(self.second_interface.close)
+            TestRepo.skymap_name, second_local_repo, prefix="file://")
         with unittest.mock.patch("activator.middleware_interface.MiddlewareInterface._run_preprocessing"):
             self.second_interface.prep_butler()
         date = (astropy.time.Time.now() - 12 * u.hour).to_value("ymdhms")
@@ -1317,7 +1273,13 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
             write_butler.collections.prepend_chain("refcats", ["emptyrun"])
 
             # Avoid collisions with other calls to prep_butler
-            with make_local_repo(tempfile.gettempdir(), read_butler, TestRepo.instname) as local_repo:
+            with unittest.mock.patch("activator.local_repo.LocalRepo._make_local_cache",
+                                     return_value=DatasetCache(3,
+                                                               {"the_monster_20250219": 10,
+                                                                "template_coadd": 30})
+                                     ):
+                local_repo = LocalRepo(tempfile.gettempdir(), read_butler, TestRepo.instname)
+            try:
                 butler_writer = DirectButlerWriter(write_butler)
                 interface = MiddlewareInterface(
                     read_butler,
@@ -1328,23 +1290,21 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
                     pipelines,
                     TestRepo.skymap_name,
                     local_repo,
-                    DatasetCache(3, {"the_monster_20250219": 10, "template_coadd": 30}),
                     prefix="file://",
                 )
-                try:
-                    with unittest.mock.patch("activator.middleware_interface."
-                                             "MiddlewareInterface._run_preprocessing"):
-                        interface.prep_butler()
+                with unittest.mock.patch("activator.middleware_interface."
+                                         "MiddlewareInterface._run_preprocessing"):
+                    interface.prep_butler()
 
-                    self.assertEqual(
-                        self._count_datasets(interface.butler, ["the_monster_20250219"],
-                                             f"{TestRepo.instname}/defaults"),
-                        2)
-                    self.assertIn(
-                        "emptyrun",
-                        interface.butler.collections.query("refcats", flatten_chains=True))
-                finally:
-                    interface.close()
+                self.assertEqual(
+                    self._count_datasets(interface.butler, ["the_monster_20250219"],
+                                         f"{TestRepo.instname}/defaults"),
+                    2)
+                self.assertIn(
+                    "emptyrun",
+                    interface.butler.collections.query("refcats", flatten_chains=True))
+            finally:
+                local_repo.close()
 
     def test_export_outputs(self):
         self.interface.export_outputs({self.raw_data_id["exposure"]})

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -53,7 +53,7 @@ from activator.caching import DatasetCache
 from activator.exception import NonRetriableError, NoGoodPipelinesError, PipelineExecutionError
 from activator.middleware_interface import get_central_butler, make_local_repo, \
     _get_sasquatch_dispatcher, MiddlewareInterface, DirectButlerWriter, \
-    _filter_datasets, _generic_query, _MissingDatasetError
+    _filter_datasets, _find_datasets_in_repo, _generic_query, _MissingDatasetError
 from shared.config import PipelinesConfig
 from shared.run_utils import get_output_run
 from shared.visit import FannedOutVisit
@@ -1085,8 +1085,10 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                 else:
                     raise ValueError("Unknown butler!")
 
-            with self.subTest(src=sorted(ref.dataId["detector"] for ref in src),
-                              existing=sorted(ref.dataId["detector"] for ref in existing)):
+            with (self.subTest(src=sorted(ref.dataId["detector"] for ref in src),
+                               existing=sorted(ref.dataId["detector"] for ref in existing)),
+                  unittest.mock.patch.object(existing_butler, "get_many_datasets", return_value=existing),
+                  ):
                 result = set(_filter_datasets(src_butler, existing_butler, query))
                 self.assertEqual(result, diff)
 
@@ -1111,7 +1113,9 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                 else:
                     raise ValueError("Unknown butler!")
 
-            with self.subTest(existing=sorted(ref.dataId["detector"] for ref in existing)):
+            with (self.subTest(existing=sorted(ref.dataId["detector"] for ref in existing)),
+                  unittest.mock.patch.object(existing_butler, "get_many_datasets", return_value=existing),
+                  ):
                 with self.assertRaises(_MissingDatasetError):
                     _filter_datasets(src_butler, existing_butler, query)
 
@@ -1142,8 +1146,10 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                 else:
                     raise ValueError("Unknown butler!")
 
-            with self.subTest(src=sorted(ref.dataId["detector"] for ref in src),
-                              existing=sorted(ref.dataId["detector"] for ref in existing)):
+            with (self.subTest(src=sorted(ref.dataId["detector"] for ref in src),
+                               existing=sorted(ref.dataId["detector"] for ref in existing)),
+                  unittest.mock.patch.object(existing_butler, "get_many_datasets", return_value=existing),
+                  ):
                 _filter_datasets(src_butler, existing_butler, query,
                                  all_callback=functools.partial(test_function, src))
 
@@ -1164,6 +1170,28 @@ class MiddlewareInterfaceTest(unittest.TestCase):
             with self.subTest(existing=sorted(ref.dataId["detector"] for ref in existing)):
                 with self.assertRaises(_MissingDatasetError):
                     _filter_datasets(src_butler, existing_butler, query, all_callback=non_callable)
+
+    def test_find_datasets_in_repo(self):
+        # Much easier to create DatasetRefs with a real repo.
+        data1 = self._make_expanded_ref(self.read_butler, "bias", {"instrument": "LSSTCam", "detector": 5},
+                                        "dummy")
+        data2 = self._make_expanded_ref(self.read_butler, "bias", {"instrument": "LSSTCam", "detector": 0},
+                                        "dummy")
+        data3 = self._make_expanded_ref(self.read_butler, "bias", {"instrument": "LSSTCam", "detector": 1},
+                                        "dummy")
+
+        combinations = [set(), {data1, data2}, {data1, data2, data3}]
+        existing_butler = unittest.mock.Mock()
+        for src, existing in itertools.product(combinations, combinations):
+            with (self.subTest(src=sorted(ref.dataId["detector"] for ref in src),
+                               existing=sorted(ref.dataId["detector"] for ref in existing)),
+                  # TODO: find an efficient way to use real Butler, otherwise the test is trivial
+                  unittest.mock.patch.object(existing_butler, "get_many_datasets",
+                                             return_value=(existing & src)),
+                  ):
+                found = set(_find_datasets_in_repo(existing_butler, src))
+                self.assertLessEqual(found, src)
+                self.assertEqual(found, existing & src)
 
     def test_generic_query(self):
         # Much easier to create DatasetRefs with a real repo.

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -206,11 +206,6 @@ class MiddlewareInterfaceTest(unittest.TestCase):
     def test_init(self):
         """Basic tests of the initialized interface object.
         """
-        # Check that the butler instance is properly configured.
-        instruments = self.interface.butler.query_dimension_records("instrument")
-        self.assertEqual(TestRepo.instname, instruments[0].name)
-        self.assertEqual(set(self.interface.butler.collections.defaults), {self.umbrella})
-
         # Check that the ingester is properly configured.
         self.assertEqual(self.interface.rawIngestTask.config.failFast, True)
         self.assertEqual(self.interface.rawIngestTask.config.transfer, "copy")
@@ -317,7 +312,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
             self.interface.prep_butler()
 
         expected_shards = {180002, 180177}
-        self._check_imports(self.interface.butler, group="1", detector=90,
+        self._check_imports(self.local_repo.butler, group="1", detector=90,
                             expected_shards=expected_shards)
 
         # Hard to test actual pipeline output, so just check we're calling it
@@ -353,7 +348,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
             self.interface.prep_butler()
 
         expected_shards = {180002, 180177}
-        self._check_imports(self.interface.butler, group="1", detector=90,
+        self._check_imports(self.local_repo.butler, group="1", detector=90,
                             expected_shards=expected_shards, have_filter=False)
 
         # Hard to test actual pipeline output, so just check we're calling it
@@ -373,7 +368,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
             self.interface.prep_butler()
 
         expected_shards = set()
-        self._check_imports(self.interface.butler, group="1", detector=90,
+        self._check_imports(self.local_repo.butler, group="1", detector=90,
                             expected_shards=expected_shards, have_spatial=False)
 
         # Hard to test actual pipeline output, so just check we're calling it
@@ -440,7 +435,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         ) as mock_pre:
             second_interface.prep_butler()
         expected_shards = {180002, 180177}
-        self._check_imports(second_interface.butler, group="2", detector=90,
+        self._check_imports(self.local_repo.butler, group="2", detector=90,
                             expected_shards=expected_shards)
         # Hard to test actual pipeline output, so just check we're calling it
         mock_pre.assert_called_once()
@@ -464,7 +459,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         ) as mock_pre:
             third_interface.prep_butler()
         expected_shards.update({180002, 180177})
-        self._check_imports(third_interface.butler, group="3", detector=91,
+        self._check_imports(self.local_repo.butler, group="3", detector=91,
                             expected_shards=expected_shards)
         # Hard to test actual pipeline output, so just check we're calling it
         mock_pre.assert_called_once()
@@ -474,7 +469,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         filename = "fakeRawImage.fits"
         filepath = os.path.join(self.input_data, filename)
         data_id, file_data = TestRepo.fake_file_data(filepath,
-                                                     self.interface.butler.dimensions,
+                                                     self.local_repo.butler.dimensions,
                                                      self.interface.instrument,
                                                      self.next_visit)
         with unittest.mock.patch.object(self.interface.rawIngestTask, "extractMetadata") as mock:
@@ -482,8 +477,8 @@ class MiddlewareInterfaceTest(unittest.TestCase):
             exp_id = self.interface.ingest_image(filename)
             self.assertEqual(exp_id, int(self.next_visit.groupId))
 
-            datasets = self.interface.butler.query_datasets('raw',
-                                                            collections=[f'{TestRepo.instname}/raw/all'])
+            datasets = self.local_repo.butler.query_datasets('raw',
+                                                             collections=[f'{TestRepo.instname}/raw/all'])
             self.assertEqual(datasets[0].dataId, data_id)
             # TODO: After raw ingest, we can define exposure dimension records
             # and check that the visits are defined
@@ -503,7 +498,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         filename = "nonexistentImage.fits"
         filepath = os.path.join(self.input_data, filename)
         _, file_data = TestRepo.fake_file_data(filepath,
-                                               self.interface.butler.dimensions,
+                                               self.local_repo.butler.dimensions,
                                                self.interface.instrument,
                                                self.next_visit)
         with (
@@ -513,8 +508,8 @@ class MiddlewareInterfaceTest(unittest.TestCase):
             mock.return_value = file_data
             self.interface.ingest_image(filename)
         # There should not be any raw files in the registry.
-        datasets = self.interface.butler.query_datasets('raw', collections=[f'{TestRepo.instname}/raw/all'],
-                                                        explain=False)
+        datasets = self.local_repo.butler.query_datasets('raw', collections=[f'{TestRepo.instname}/raw/all'],
+                                                         explain=False)
         self.assertEqual(datasets, [])
 
     def test_get_observed_skyangle(self):
@@ -538,7 +533,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         filename = "fakeRawImage.fits"
         filepath = os.path.join(self.input_data, filename)
         _, file_data = TestRepo.fake_file_data(filepath,
-                                               self.interface.butler.dimensions,
+                                               self.local_repo.butler.dimensions,
                                                self.interface.instrument,
                                                self.next_visit)
         with unittest.mock.patch.object(self.interface.rawIngestTask, "extractMetadata") as mock:
@@ -554,7 +549,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                                         dome=FannedOutVisit.Dome.CLOSED,
                                         )
         _, eng_data = TestRepo.fake_file_data(filepath,
-                                              self.interface.butler.dimensions,
+                                              self.local_repo.butler.dimensions,
                                               self.interface.instrument,
                                               eng_visit)
         with unittest.mock.patch.object(self.interface.rawIngestTask, "extractMetadata") as mock:
@@ -604,7 +599,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
             "test_provenance",
             # Mocked QGs do not have realistic dimensions, and provenance
             # dataset types need to have the same dimensions.
-            self.interface.butler.dimensions.conform(["detector"]),
+            self.local_repo.butler.dimensions.conform(["detector"]),
             "ProvenanceQuantumGraph"
         )
         with (
@@ -729,7 +724,7 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         filename = "fakeRawImage.fits"
         filepath = os.path.join(self.input_data, filename)
         _, file_data = TestRepo.fake_file_data(filepath,
-                                               self.interface.butler.dimensions,
+                                               self.local_repo.butler.dimensions,
                                                self.interface.instrument,
                                                self.next_visit)
         with unittest.mock.patch.object(self.interface.rawIngestTask, "extractMetadata") as mock:
@@ -1036,12 +1031,12 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
 
         with unittest.mock.patch("activator.local_repo.LocalRepo._make_local_cache",
                                  return_value=DatasetCache(2)):
-            local_repo = LocalRepo(tempfile.gettempdir(), read_butler, TestRepo.instname)
-        self.addCleanup(local_repo.close)
+            self.local_repo = LocalRepo(tempfile.gettempdir(), read_butler, TestRepo.instname)
+        self.addCleanup(self.local_repo.close)
         with unittest.mock.patch("activator.local_repo.LocalRepo._make_local_cache",
                                  return_value=DatasetCache(2)):
-            second_local_repo = LocalRepo(tempfile.gettempdir(), read_butler, TestRepo.instname)
-        self.addCleanup(second_local_repo.close)
+            self.second_local_repo = LocalRepo(tempfile.gettempdir(), read_butler, TestRepo.instname)
+        self.addCleanup(self.second_local_repo.close)
 
         apdb_dir = tempfile.TemporaryDirectory(ignore_cleanup_errors=True)
         self.addCleanup(apdb_dir.cleanup)
@@ -1094,14 +1089,14 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
         butler_writer = DirectButlerWriter(self.write_butler)
         self.interface = MiddlewareInterface(read_butler, butler_writer, self.input_data, self.next_visit,
                                              pre_pipelines_full, pipelines, TestRepo.skymap_name,
-                                             local_repo,
+                                             self.local_repo,
                                              prefix="file://")
         with unittest.mock.patch("activator.middleware_interface.MiddlewareInterface._run_preprocessing"):
             self.interface.prep_butler()
         filename = "fakeRawImage.fits"
         filepath = os.path.join(self.input_data, filename)
         self.raw_data_id, file_data = TestRepo.fake_file_data(filepath,
-                                                              self.interface.butler.dimensions,
+                                                              self.local_repo.butler.dimensions,
                                                               self.interface.instrument,
                                                               self.next_visit)
         self.group_data_id = {(k if k != "exposure" else "group"): (v if k != "exposure" else str(v))
@@ -1109,14 +1104,14 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
 
         self.second_visit = dataclasses.replace(self.next_visit, groupId="2")
         self.second_data_id, second_file_data = TestRepo.fake_file_data(filepath,
-                                                                        self.interface.butler.dimensions,
+                                                                        self.local_repo.butler.dimensions,
                                                                         self.interface.instrument,
                                                                         self.second_visit)
         self.second_group_data_id = {(k if k != "exposure" else "group"): (v if k != "exposure" else str(v))
                                      for k, v in self.second_data_id.required.items()}
         self.second_interface = MiddlewareInterface(
             read_butler, butler_writer, self.input_data, self.second_visit, pre_pipelines_full, pipelines,
-            TestRepo.skymap_name, second_local_repo, prefix="file://")
+            TestRepo.skymap_name, self.second_local_repo, prefix="file://")
         with unittest.mock.patch("activator.middleware_interface.MiddlewareInterface._run_preprocessing"):
             self.second_interface.prep_butler()
         date = (astropy.time.Time.now() - 12 * u.hour).to_value("ymdhms")
@@ -1158,26 +1153,26 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
         butler_tests.addDatasetType(self.write_butler, "history_diaSource",
                                     {"instrument", "group", "detector"},
                                     "ArrowAstropy")
-        butler_tests.addDatasetType(self.interface.butler, "history_diaSource",
+        butler_tests.addDatasetType(self.local_repo.butler, "history_diaSource",
                                     {"instrument", "group", "detector"},
                                     "ArrowAstropy")
-        butler_tests.addDatasetType(self.second_interface.butler, "history_diaSource",
+        butler_tests.addDatasetType(self.second_local_repo.butler, "history_diaSource",
                                     {"instrument", "group", "detector"},
                                     "ArrowAstropy")
         butler_tests.addDatasetType(self.write_butler, "calexp",
                                     {"instrument", "visit", "detector"},
                                     "ExposureF")
-        butler_tests.addDatasetType(self.interface.butler, "calexp",
+        butler_tests.addDatasetType(self.local_repo.butler, "calexp",
                                     {"instrument", "visit", "detector"},
                                     "ExposureF")
-        butler_tests.addDatasetType(self.second_interface.butler, "calexp",
+        butler_tests.addDatasetType(self.second_local_repo.butler, "calexp",
                                     {"instrument", "visit", "detector"},
                                     "ExposureF")
-        self.interface.butler.put(cat, "history_diaSource", self.group_data_id, run=self.preprocessing_run)
-        self.second_interface.butler.put(cat, "history_diaSource", self.second_group_data_id,
-                                         run=self.preprocessing_run)
-        self.interface.butler.put(exp, "calexp", self.processed_data_id, run=self.output_run)
-        self.second_interface.butler.put(exp, "calexp", self.second_processed_data_id, run=self.output_run)
+        self.local_repo.butler.put(cat, "history_diaSource", self.group_data_id, run=self.preprocessing_run)
+        self.second_local_repo.butler.put(cat, "history_diaSource", self.second_group_data_id,
+                                          run=self.preprocessing_run)
+        self.local_repo.butler.put(exp, "calexp", self.processed_data_id, run=self.output_run)
+        self.second_local_repo.butler.put(exp, "calexp", self.second_processed_data_id, run=self.output_run)
 
     def _count_datasets(self, butler, types, collections):
         count = 0
@@ -1234,12 +1229,12 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
                     interface.prep_butler()
 
                 self.assertEqual(
-                    self._count_datasets(interface.butler, ["the_monster_20250219"],
+                    self._count_datasets(local_repo.butler, ["the_monster_20250219"],
                                          f"{TestRepo.instname}/defaults"),
                     2)
                 self.assertIn(
                     "emptyrun",
-                    interface.butler.collections.query("refcats", flatten_chains=True))
+                    local_repo.butler.collections.query("refcats", flatten_chains=True))
             finally:
                 local_repo.close()
 

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -105,8 +105,8 @@ class MiddlewareInterfaceTest(unittest.TestCase):
     """Test the MiddlewareInterface class with faked data.
     """
     def setUp(self):
-        self.data_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data")
-        self.central_repo = os.path.join(self.data_dir, "central_repo")
+        self.data_dir = TestRepo.data_dir
+        self.central_repo = TestRepo.repo_dir
         self.umbrella = f"{TestRepo.instname}/defaults"
         self.read_butler = Butler(self.central_repo,
                                   writeable=False,
@@ -1095,8 +1095,7 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
         be awkward if this method returned a Butler instead.
         """
         # Copy test data to fresh Butler to allow write tests.
-        data_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data")
-        data_repo = os.path.join(data_dir, "central_repo")
+        data_repo = TestRepo.repo_dir
         self.central_repo = tempfile.TemporaryDirectory()
         # TemporaryDirectory warns on leaks
         self.addCleanup(tempfile.TemporaryDirectory.cleanup, self.central_repo)
@@ -1140,8 +1139,7 @@ class MiddlewareInterfaceWriteableTest(unittest.TestCase):
                                    skymap=TestRepo.skymap_name,
                                    writeable=True)
         self.addCleanup(self.write_butler.close)
-        data_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), "data")
-        self.input_data = os.path.join(data_dir, "input_data")
+        self.input_data = os.path.join(TestRepo.data_dir, "input_data")
 
         local_repo = make_local_repo(tempfile.gettempdir(), read_butler, TestRepo.instname)
         self.local_cache = DatasetCache(2)

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -53,7 +53,6 @@ from activator.local_repo import LocalRepo
 from activator.middleware_interface import get_central_butler, \
     _get_sasquatch_dispatcher, MiddlewareInterface, DirectButlerWriter
 from shared.config import PipelinesConfig
-from shared.run_utils import get_output_run
 from shared.visit import FannedOutVisit
 
 from mock_central_repo import TestRepo
@@ -927,68 +926,6 @@ class MiddlewareInterfaceTest(unittest.TestCase):
         for dataset in butler.query_datasets(dataset_type, collections=collection, data_id=data_id,
                                              find_first=False, explain=False):
             self.fail(f"{dataset} matches {dataset_type}@{data_id} in {collection}.")
-
-    def test_clean_local_repo(self):
-        """Test that clean_local_repo removes old datasets from the datastore.
-        """
-        # Safe to define custom dataset types and IDs, because the repository
-        # is regenerated for each test.
-        butler = self.interface.butler
-        raw_data_id, _ = TestRepo.fake_file_data("foo.bar",
-                                                 butler.dimensions,
-                                                 self.interface.instrument,
-                                                 self.next_visit)
-        calib_data_id_1 = {k: v for k, v in raw_data_id.required.items() if k in {"instrument", "detector"}}
-        calib_data_id_2 = {"instrument": self.interface.instrument.getName(), "detector": 1}
-        calib_data_id_3 = {"instrument": self.interface.instrument.getName(), "detector": 2}
-        calib_data_id_4 = {"instrument": self.interface.instrument.getName(), "detector": 3}
-        processed_data_id = {(k if k != "exposure" else "visit"): v for k, v in raw_data_id.required.items()}
-        butler_tests.addDataIdValue(butler, "exposure", raw_data_id["exposure"])
-        butler_tests.addDataIdValue(butler, "visit", processed_data_id["visit"])
-        butler_tests.addDatasetType(butler, "raw", raw_data_id.required.keys(), "Exposure")
-        butler_tests.addDatasetType(butler, "src", processed_data_id.keys(), "SourceCatalog")
-        butler_tests.addDatasetType(butler, "calexp", processed_data_id.keys(), "ExposureF")
-        butler_tests.addDatasetType(butler, "bias", calib_data_id_1.keys(), "ExposureF")
-
-        exp = lsst.afw.image.ExposureF(20, 20)
-        cat = lsst.afw.table.SourceCatalog()
-        # Since we're not calling prep_butler, need to set up the collections by hand
-        raw_collection = self.interface.instrument.makeDefaultRawIngestRunName()
-        butler.collections.register(raw_collection, CollectionType.RUN)
-        out_collection = get_output_run(self.interface.instrument, self.deploy_id,
-                                        "ApPipe.yaml", self.interface._day_obs)
-        butler.collections.register(out_collection, CollectionType.RUN)
-        # Avoid conflict with the original calib chain
-        calib_collection = self.interface.instrument.makeCalibrationCollectionName("dummy")
-        butler.collections.register(calib_collection, CollectionType.RUN)
-        chain = self.interface.instrument.makeUmbrellaCollectionName()
-        butler.collections.register(chain, CollectionType.CHAINED)
-        butler.collections.redefine_chain(chain, [out_collection, raw_collection, calib_collection])
-
-        butler.put(exp, "raw", raw_data_id, run=raw_collection)
-        butler.put(cat, "src", processed_data_id, run=out_collection)
-        butler.put(exp, "calexp", processed_data_id, run=out_collection)
-        bias_1 = butler.put(exp, "bias", calib_data_id_1, run=calib_collection)
-        bias_2 = butler.put(exp, "bias", calib_data_id_2, run=calib_collection)
-        bias_3 = butler.put(exp, "bias", calib_data_id_3, run=calib_collection)
-        bias_4 = butler.put(exp, "bias", calib_data_id_4, run=calib_collection)
-        with self.assertWarns(RuntimeWarning):  # Deliberately overflowing cache
-            self.local_repo._cache.update([bias_1, bias_2, bias_3, bias_4, ])
-        self._assert_in_collection(butler, "*", "raw", raw_data_id)
-        self._assert_in_collection(butler, "*", "src", processed_data_id)
-        self._assert_in_collection(butler, "*", "calexp", processed_data_id)
-        self._assert_in_collection(butler, "*", "bias", calib_data_id_1)
-        self._assert_in_collection(butler, "*", "bias", calib_data_id_2)
-        self._assert_in_collection(butler, "*", "bias", calib_data_id_3)
-
-        self.interface.clean_local_repo()
-        self._assert_not_in_collection(butler, "*", "raw", raw_data_id)
-        self._assert_not_in_collection(butler, "*", "src", processed_data_id)
-        self._assert_not_in_collection(butler, "*", "calexp", processed_data_id)
-        # Default cache has size 2, so one of the biases should have been removed
-        self._check_cache_vs_collection(butler, self.local_repo._cache, bias_1)
-        self._check_cache_vs_collection(butler, self.local_repo._cache, bias_2)
-        self._check_cache_vs_collection(butler, self.local_repo._cache, bias_3)
 
     def _check_cache_vs_collection(self, butler, cache, ref):
         if ref in cache:

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -52,7 +52,7 @@ from activator.caching import DatasetCache
 from activator.exception import NonRetriableError, NoGoodPipelinesError, PipelineExecutionError
 from activator.middleware_interface import get_central_butler, make_local_repo, \
     _get_sasquatch_dispatcher, MiddlewareInterface, DirectButlerWriter, \
-    _find_datasets_in_repo, _generic_query
+    _find_datasets_in_repo
 from shared.config import PipelinesConfig
 from shared.run_utils import get_output_run
 from shared.visit import FannedOutVisit
@@ -1079,38 +1079,6 @@ class MiddlewareInterfaceTest(unittest.TestCase):
                 found = set(_find_datasets_in_repo(existing_butler, src))
                 self.assertLessEqual(found, src)
                 self.assertEqual(found, existing & src)
-
-    def test_generic_query(self):
-        # Much easier to create DatasetRefs with a real repo.
-        data1 = self._make_expanded_ref(self.read_butler, "bias", {"instrument": "LSSTCam", "detector": 5},
-                                        "dummy")
-        data2 = self._make_expanded_ref(self.read_butler, "bias", {"instrument": "LSSTCam", "detector": 0},
-                                        "dummy")
-        data3 = self._make_expanded_ref(self.read_butler, "bias", {"instrument": "LSSTCam", "detector": 1},
-                                        "dummy")
-        refs = [data1, data2, data3]
-
-        butler = unittest.mock.Mock(**{"query_datasets.return_value": refs})
-        result = _generic_query(["bias"], instrument="LSSTCam")(butler)
-
-        butler.query_datasets.assert_called_once()
-        self.assertEqual(butler.query_datasets.call_args.args, ("bias", ))
-        # Implementation may add other kwargs.
-        self.assertEqual(butler.query_datasets.call_args.kwargs["instrument"], "LSSTCam")
-        self.assertEqual(set(result), set(refs))
-
-    def test_generic_query_nodim(self):
-        """Test that _generic_query provides the correct values when
-        a repository is missing not only datasets, but the dimensions
-        to define them.
-        """
-        butler = unittest.mock.Mock(**{
-            "query_datasets.side_effect": lsst.daf.butler.registry.DataIdValueError(
-                f"Unknown values specified for governor dimension instrument: {TestRepo.instname}")
-        })
-        result = _generic_query(["bias"], instrument=TestRepo.instname)(butler)
-
-        self.assertEqual(result, set())
 
 
 class MiddlewareInterfaceWriteableTest(unittest.TestCase):


### PR DESCRIPTION
This PR moves local repo initialization, cleanup, and integrity checking out of `MiddlewareInterface` and into a new `LocalRepo` class. This is a step towards disentangling the multiple responsibilities that have slipped into `MiddlewareInterface`.